### PR TITLE
Refactor #44 - Interactive commands

### DIFF
--- a/src/Console/Commands/AddPaymentProvider.php
+++ b/src/Console/Commands/AddPaymentProvider.php
@@ -17,7 +17,7 @@ class AddPaymentProvider extends Command
      * @var string
      */
     protected $signature = 'payment:add-provider
-                            {provider : The payment provider name}
+                            {provider? : The payment provider name}
                             {--slug= : The payment provider dev name}
                             {--manager : Generate class for payment management}
                             {--processor : Generate class for payment processing}
@@ -100,7 +100,14 @@ class AddPaymentProvider extends Command
      */
     protected function setProperties()
     {
-        $this->name = trim($this->argument('provider'));
-        $this->slug = PaymentProvider::slugify($this->option('slug') ?? $this->name);
+        $this->name = trim(
+            $this->argument('provider') ?? 
+            $this->ask('What provider would you like to add?')
+        );
+
+        $this->slug = PaymentProvider::slugify(
+            $this->option('slug') ?? 
+            $this->ask("What slug would you like to use for the {$this->name} provider?", PaymentProvider::slugify($this->name))
+        );
     }
 }

--- a/src/Console/stubs/payment-merchant-migration.stub
+++ b/src/Console/stubs/payment-merchant-migration.stub
@@ -13,13 +13,18 @@ class {{ class }} extends Migration
      */
     public function up()
     {
-        $provider = PaymentProvider::where('slug', '{{ provider }}')->first();
-
-        PaymentMerchant::create([
-            'provider_id' => $provider->id,
-            'name' => '{{ name }}',
+        $merchant = PaymentMerchant::create([
             'slug' => '{{ slug }}',
+            'name' => '{{ name }}',
         ]);
+
+        $providers = PaymentProvider::whereIn('slug', ['{{ providers }}'])->get();
+
+        $merchant->providers()->sync(
+            $providers->mapWithKeys(function ($provider) {
+                return [$provider->id => ['is_default' => '{{ defaultProvider }}' === $provider->slug]];
+            })->toArray()
+        );
     }
 
     /**

--- a/src/Models/PaymentMerchant.php
+++ b/src/Models/PaymentMerchant.php
@@ -22,9 +22,9 @@ class PaymentMerchant extends Model
         return PaymentMerchantFactory::new();
     }
 
-    public function provider()
+    public function providers()
     {
-        return $this->belongsTo(config('payment.models.' . PaymentProvider::class, PaymentProvider::class));
+        return $this->belongsToMany(config('payment.models.' . PaymentProvider::class, PaymentProvider::class), 'payment_merchant_provider', 'merchant_id', 'provider_id');
     }
 
     public function wallets()

--- a/src/Models/PaymentProvider.php
+++ b/src/Models/PaymentProvider.php
@@ -24,7 +24,7 @@ class PaymentProvider extends Model
 
     public function merchants()
     {
-        return $this->hasMany(config('payment.models.' . PaymentMerchant::class, PaymentMerchant::class));
+        return $this->belongsToMany(config('payment.models.' . PaymentMerchant::class, PaymentMerchant::class), 'payment_merchant_provider', 'provider_id', 'merchant_id');
     }
 
     public function wallets()

--- a/src/database/factories/PaymentMerchantFactory.php
+++ b/src/database/factories/PaymentMerchantFactory.php
@@ -22,14 +22,9 @@ class PaymentMerchantFactory extends Factory
      */
     public function definition()
     {
-        $provider = PaymentProvider::inRandomOrder()->firstOr(function () {
-            return PaymentProvider::factory()->create();
-        });
-
         $name = $this->faker->unique()->company();
 
         return [
-            'provider_id' => $provider->id,
             'name' => $name,
             'slug' => PaymentMerchant::slugify($name),
         ];

--- a/src/database/factories/WalletFactory.php
+++ b/src/database/factories/WalletFactory.php
@@ -4,6 +4,7 @@ namespace rkujawa\LaravelPaymentGateway\Database\Factories;
 
 use Illuminate\Database\Eloquent\Factories\Factory;
 use rkujawa\LaravelPaymentGateway\Models\PaymentMerchant;
+use rkujawa\LaravelPaymentGateway\Models\PaymentProvider;
 use rkujawa\LaravelPaymentGateway\Models\Wallet;
 
 class WalletFactory extends Factory
@@ -26,8 +27,14 @@ class WalletFactory extends Factory
             return PaymentMerchant::factory()->create();
         });
 
+        $provider = $merchant->providers()->inRandomOrder()->firstOr(function () {
+            return PaymentProvider::factory()->create();
+        });
+
+        $merchant->providers()->syncWithoutDetaching([$provider->id]);
+
         return [
-            'provider_id' => $merchant->provider->id,
+            'provider_id' => $provider->id,
             'merchant_id' => $merchant->id,
             'token' => $this->faker->uuid(),
         ];

--- a/src/database/migrations/2021_01_01_000000_create_base_payment_tables.php
+++ b/src/database/migrations/2021_01_01_000000_create_base_payment_tables.php
@@ -22,11 +22,19 @@ class CreateBasePaymentTables extends Migration
 
         Schema::create('payment_merchants', function (Blueprint $table) {
             $table->mediumIncrements('id');
-            $table->unsignedSmallInteger('provider_id');
             $table->string('name');
             $table->string('slug')->unique();
             $table->timestamps();
+        });
 
+        Schema::create('payment_merchant_provider', function (Blueprint $table) {
+            $table->increments('id');
+            $table->unsignedMediumInteger('merchant_id');
+            $table->unsignedSmallInteger('provider_id');
+            $table->boolean('is_default')->default(false);
+            $table->timestamps();
+
+            $table->foreign('merchant_id')->references('id')->on('payment_merchants')->onDelete('cascade');
             $table->foreign('provider_id')->references('id')->on('payment_providers')->onDelete('cascade');
         });
 
@@ -112,6 +120,7 @@ class CreateBasePaymentTables extends Migration
         Schema::dropIfExists('payment_methods');
         Schema::dropIfExists('payment_types');
         Schema::dropIfExists('wallets');
+        Schema::dropIfExists('payment_merchant_provider');
         Schema::dropIfExists('payment_merchants');
         Schema::dropIfExists('payment_providers');
     }

--- a/tests/Feature/AddPaymentMerchantCommandTest.php
+++ b/tests/Feature/AddPaymentMerchantCommandTest.php
@@ -5,6 +5,7 @@ namespace rkujawa\LaravelPaymentGateway\Tests;
 use Exception;
 use InvalidArgumentException;
 use rkujawa\LaravelPaymentGateway\Models\PaymentMerchant;
+use rkujawa\LaravelPaymentGateway\Models\PaymentProvider;
 
 class PaymentMerchantCommandTest extends TestCase
 {
@@ -17,7 +18,6 @@ class PaymentMerchantCommandTest extends TestCase
             ->artisan('payment:add-merchant', [
                 'merchant' => $paymentMerchant->name,
                 '--slug' => $paymentMerchant->slug,
-                'provider' => $paymentMerchant->provider->slug
             ])
             ->expectsOutput('The migration to add ' . $paymentMerchant->name . ' payment merchant has been generated.')
             ->expectsConfirmation('Would you like to run the migration?')
@@ -39,7 +39,6 @@ class PaymentMerchantCommandTest extends TestCase
             ->artisan('payment:add-merchant', [
                 'merchant' => $paymentMerchant->name,
                 '--slug' => $paymentMerchant->slug,
-                'provider' => $paymentMerchant->provider->slug
             ])
             ->expectsOutput('The migration to add ' . $paymentMerchant->name . ' payment merchant has been generated.')
             ->expectsConfirmation('Would you like to run the migration?', 'yes')
@@ -57,7 +56,6 @@ class PaymentMerchantCommandTest extends TestCase
             ->artisan('payment:add-merchant', [
                 'merchant' => $paymentMerchant->name,
                 '--slug' => $paymentMerchant->slug,
-                'provider' => $paymentMerchant->provider->slug
             ])
             ->expectsOutput('The migration to add ' . $paymentMerchant->name . ' payment merchant has been generated.')
             ->expectsConfirmation('Would you like to run the migration?')
@@ -68,12 +66,88 @@ class PaymentMerchantCommandTest extends TestCase
                 ->artisan('payment:add-merchant', [
                     'merchant' => $paymentMerchant->name,
                     '--slug' => $paymentMerchant->slug,
-                    'provider' => $paymentMerchant->provider->slug
                 ])
                 ->doesntExpectOutput('The migration to add ' . $paymentMerchant->name . ' payment merchant has been generated.')
                 ->assertExitCode(0);
         } catch (Exception $e) {
             $this->assertEquals(InvalidArgumentException::class, get_class($e));
         }
+    }
+
+    /** @test */
+    public function add_payment_merchant_command_will_not_prompt_to_run_migration_when_passing_skip_migration_option()
+    {
+        $paymentMerchant = PaymentMerchant::factory()->make();
+
+        $this
+            ->artisan('payment:add-merchant', [
+                'merchant' => $paymentMerchant->name,
+                '--slug' => $paymentMerchant->slug,
+                '--skip-migration' => true,
+            ])
+            ->expectsOutput('The migration to add '.$paymentMerchant->name.' payment merchant has been generated.')
+            ->assertExitCode(0);
+        
+        $this->artisan('migrate');
+
+        $this->assertDatabaseHas('payment_merchants', ['slug' => $paymentMerchant->slug]);
+    }
+
+    /** @test */
+    public function add_payment_merchant_command_will_prompt_for_missing_arguments()
+    {
+        $paymentMerchant = PaymentMerchant::factory()->make();
+
+        $this
+            ->artisan('payment:add-merchant')
+            ->expectsQuestion('What merchant would you like to add?', $paymentMerchant->name)
+            ->expectsQuestion('What slug would you like to use for the '.$paymentMerchant->name.' merchant?', $paymentMerchant->slug)
+            ->expectsOutput('The migration to add ' . $paymentMerchant->name . ' payment merchant has been generated.')
+            ->expectsConfirmation('Would you like to run the migration?', 'yes')
+            ->assertExitCode(0);
+
+        $this->assertDatabaseHas('payment_merchants', ['slug' => $paymentMerchant->slug]);
+    }
+
+    /** @test */
+    public function add_payment_merchant_command_will_prompt_to_choose_related_providers_if_exists_in_config()
+    {
+        $paymentProvider = PaymentProvider::factory()->create();
+        $paymentMerchant = PaymentMerchant::factory()->make();
+
+        config(['payment.providers' => [$paymentProvider->slug]]);
+
+        $this
+            ->artisan('payment:add-merchant', [
+                'merchant' => $paymentMerchant->name,
+                '--slug' => $paymentMerchant->slug,
+            ])
+            ->expectsChoice('Which payment providers will the '.$paymentMerchant->name.' merchant be using? (First chosen will be default)', $paymentProvider->slug, config('payment.providers'))
+            ->expectsOutput('The migration to add ' . $paymentMerchant->name . ' payment merchant has been generated.')
+            ->expectsConfirmation('Would you like to run the migration?', 'yes')
+            ->assertExitCode(0);
+
+        $this->assertDatabaseHas('payment_merchants', ['slug' => $paymentMerchant->slug]);
+    }
+
+    /** @test */
+    public function add_payment_merchant_command_will_not_prompt_for_providers_if_skip_provider_flag_is_provided()
+    {
+        $paymentProvider = PaymentProvider::factory()->create();
+        $paymentMerchant = PaymentMerchant::factory()->make();
+
+        config(['payment.providers' => [$paymentProvider->slug]]);
+
+        $this
+            ->artisan('payment:add-merchant', [
+                'merchant' => $paymentMerchant->name,
+                '--slug' => $paymentMerchant->slug,
+                '--skip-provider' => true
+            ])
+            ->expectsOutput('The migration to add ' . $paymentMerchant->name . ' payment merchant has been generated.')
+            ->expectsConfirmation('Would you like to run the migration?', 'yes')
+            ->assertExitCode(0);
+
+        $this->assertDatabaseHas('payment_merchants', ['slug' => $paymentMerchant->slug]);
     }
 }


### PR DESCRIPTION
### **What does this PR do?** :robot:

- Prompts for input when none is specified for the `payment:add-provider` and `payment:add-merchant` commands.
- Replaces the one to many relationship between `payment_providers` & `payment_merchants` with a many to many relationship (`payment_merchant_provider`).

### **Where should the reviewer start?** :round_pushpin:
I would suggest reviewing the relationship functionality between the `PaymentProvider::class` and `PaymentMerchant::class` models, as well as the `payment:add-merchant` command as the relationship change affected the functionality of this command.

### **How should this be tested?** :microscope:
Require the `r-kujawa/laravel-payment-gateway` package and run the `php artisan migrate` command to have all the required tables in your database. Once that is done, you may tinker with the different commands and config (`payment.php`).

### **Any background context you would like to provide?** :construction:
This is the first steps 👣  for #28.

### **Does this relate to any story?** :link:
Closes #44 
