### PR TITLE
Refactor #47 - Prefer database over config

### DIFF
--- a/src/Console/Commands/AddPaymentMerchant.php
+++ b/src/Console/Commands/AddPaymentMerchant.php
@@ -102,7 +102,7 @@ class AddPaymentMerchant extends Command
             $this->ask("What slug would you like to use for the {$this->name} merchant?", PaymentMerchant::slugify($this->name))
         );
 
-        if ($this->option('skip-provider') || ($providers = collect(config('payment.providers', [])))->isEmpty()) {
+        if ($this->option('skip-provider') || ($providers = PaymentProvider::all())->isEmpty()) {
             $this->providers = '';
             $this->defaultProvider = '';
 
@@ -111,7 +111,7 @@ class AddPaymentMerchant extends Command
 
         $selectedProviders = $this->choice(
             "Which payment providers will the {$this->name} merchant be using? (First chosen will be default)",
-            $providers->toArray(),
+            $providers->pluck('slug')->toArray(),
             null,
             null,
             true

--- a/src/Console/stubs/payment-gateway.stub
+++ b/src/Console/stubs/payment-gateway.stub
@@ -6,6 +6,11 @@ class {{ name }}PaymentGateway
 {
     protected $client;
 
+    /**
+     * Set the gateway $client
+     *
+     * @param  \rkujawa\LaravelPaymentGateway\Models\PaymentMerchant|null $merchant
+     */
     public function __construct($merchant = null)
     {
         // Set the http client.

--- a/src/PaymentService.php
+++ b/src/PaymentService.php
@@ -139,7 +139,7 @@ class PaymentService
      */
     public function getDefaultMerchant()
     {
-        return config('payment.defaults.merchants');
+        return config('payment.defaults.merchant');
     }
 
     /**
@@ -156,7 +156,7 @@ class PaymentService
             $merchant = PaymentMerchant::where('slug', $merchant)->orWhere('id', $merchant)->first();
         }
 
-        if (is_null($merchant) || (! $merchant->exists) || (! $this->getProvider()->merchants()->where('id', $merchant->id)->exists())) {
+        if (is_null($merchant) || (! $merchant->exists) || (! $merchant->providers()->where('slug', $this->getProvider()->slug)->exists())) {
             throw new Exception('Unsupported merchant.');
         }
 

--- a/src/config/payment.php
+++ b/src/config/payment.php
@@ -14,26 +14,24 @@ return [
     */
     'defaults' => [
         'provider' => '',
+        'merchant' => '',
     ],
 
     /*
     |--------------------------------------------------------------------------
-    | Supported Payment Providers
+    | Payment Provider Configurations
     |--------------------------------------------------------------------------
     |
-    | This option defines the payment providers that your application supports along with
-    | their merchants. Specify the providers manually once they are ready for production.
-    | You may also specify the service class paths if they differ from the default paths
+    | Here you may specify the service class path for each provider ('path') or, 
+    | if they differ from the default paths, you may also specify the exact class
+    | path for each of the services ('processor', 'manager').
     |
     */
     'providers' => [
-        '' => [
-            'merchants' => [
-                '',
-            ],
-        ],
+        // '' => [
+        //     'path' => 'App\\Services\\Payment'
+        // ],
     ],
-
     
     /*
     |--------------------------------------------------------------------------

--- a/tests/Feature/AddPaymentMerchantCommandTest.php
+++ b/tests/Feature/AddPaymentMerchantCommandTest.php
@@ -85,7 +85,7 @@ class PaymentMerchantCommandTest extends TestCase
                 '--slug' => $paymentMerchant->slug,
                 '--skip-migration' => true,
             ])
-            ->expectsOutput('The migration to add '.$paymentMerchant->name.' payment merchant has been generated.')
+            ->expectsOutput('The migration to add ' . $paymentMerchant->name . ' payment merchant has been generated.')
             ->assertExitCode(0);
         
         $this->artisan('migrate');

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -2,6 +2,7 @@
 
 namespace rkujawa\LaravelPaymentGateway\Tests;
 
+use Illuminate\Filesystem\Filesystem;
 use rkujawa\LaravelPaymentGateway\PaymentServiceProvider;
 
 class TestCase extends \Orchestra\Testbench\TestCase
@@ -14,6 +15,9 @@ class TestCase extends \Orchestra\Testbench\TestCase
     protected function setUp(): void
     {
         parent::setUp();
+
+        // TODO: Make this a separate function and prevent using the \Illuminate\Filesystem\Filesystem
+        (new Filesystem)->cleanDirectory(database_path('migrations'));
 
         $this->artisan('migrate');
     }


### PR DESCRIPTION
### **What does this PR do?** :robot:

- Applies changes to the code to prefer data stored in the database over the config file.
- Removes some dependency on the package's config (`payment.php`) (data duplication).

### **Any background context you would like to provide?** :construction:
🔴  This updates the way the `{Provider}PaymentGateway::class` gets generated. Now the `__construct($merchant)` method will be receiving an instance of `PaymentMerchant::class` instead of the merchant's slug.

### **Does this relate to any story?** :link:
Closes #47 
