### PR TITLE
Prefer class over interface and other stuff

### DIFF
--- a/src/Console/stubs/payment-processor-service.stub
+++ b/src/Console/stubs/payment-processor-service.stub
@@ -2,9 +2,9 @@
 
 namespace App\Services\Payment;
 
-use rkujawa\LaravelPaymentGateway\Contracts\PaymentProcesser;
+use rkujawa\LaravelPaymentGateway\Contracts\PaymentProcessor;
 
-class {{ name }}PaymentProcessor extends {{ name }}PaymentGateway implements PaymentProcesser
+class {{ name }}PaymentProcessor extends {{ name }}PaymentGateway implements PaymentProcessor
 {
     /**
      * @param array|mixed $data

--- a/src/Contracts/PaymentGateway.php
+++ b/src/Contracts/PaymentGateway.php
@@ -2,7 +2,7 @@
 
 namespace rkujawa\LaravelPaymentGateway\Contracts;
 
-interface PaymentGateway extends PaymentManager, PaymentProcesser
+interface PaymentGateway extends PaymentManager, PaymentProcessor
 {
     
 }

--- a/src/Contracts/PaymentProcessor.php
+++ b/src/Contracts/PaymentProcessor.php
@@ -2,7 +2,7 @@
 
 namespace rkujawa\LaravelPaymentGateway\Contracts;
 
-interface PaymentProcesser
+interface PaymentProcessor
 {
     /**
      * @param array|mixed $data

--- a/src/Facades/Payment.php
+++ b/src/Facades/Payment.php
@@ -3,7 +3,7 @@
 namespace rkujawa\LaravelPaymentGateway\Facades;
 
 use Illuminate\Support\Facades\Facade;
-use rkujawa\LaravelPaymentGateway\Contracts\PaymentGateway;
+use rkujawa\LaravelPaymentGateway\PaymentGateway;
 
 class Payment extends Facade
 {

--- a/src/PaymentGateway.php
+++ b/src/PaymentGateway.php
@@ -2,9 +2,9 @@
 
 namespace rkujawa\LaravelPaymentGateway;
 
-use rkujawa\LaravelPaymentGateway\Contracts\PaymentGateway;
+use rkujawa\LaravelPaymentGateway\Contracts\PaymentGateway as PaymentGatewayContract;
 
-class LaravelPaymentGateway extends PaymentService implements PaymentGateway
+class PaymentGateway extends PaymentService implements PaymentGatewayContract
 {
     /**
      * @param \rkujawa\LaravelPaymentGateway\Contracts\BillableContract $billable

--- a/src/PaymentServiceProvider.php
+++ b/src/PaymentServiceProvider.php
@@ -6,7 +6,6 @@ use Illuminate\Support\ServiceProvider;
 use rkujawa\LaravelPaymentGateway\Console\Commands\AddPaymentMerchant;
 use rkujawa\LaravelPaymentGateway\Console\Commands\AddPaymentProvider;
 use rkujawa\LaravelPaymentGateway\Console\Commands\AddPaymentType;
-use rkujawa\LaravelPaymentGateway\Contracts\PaymentGateway;
 
 class PaymentServiceProvider extends ServiceProvider
 {
@@ -38,7 +37,7 @@ class PaymentServiceProvider extends ServiceProvider
     public function register()
     {
         $this->app->singleton(PaymentGateway::class, function ($app) {
-            return new LaravelPaymentGateway();
+            return new PaymentGateway();
         });
     }
 }

--- a/src/database/factories/PaymentMerchantFactory.php
+++ b/src/database/factories/PaymentMerchantFactory.php
@@ -4,7 +4,6 @@ namespace rkujawa\LaravelPaymentGateway\Database\Factories;
 
 use Illuminate\Database\Eloquent\Factories\Factory;
 use rkujawa\LaravelPaymentGateway\Models\PaymentMerchant;
-use rkujawa\LaravelPaymentGateway\Models\PaymentProvider;
 
 class PaymentMerchantFactory extends Factory
 {

--- a/src/database/factories/PaymentTransactionFactory.php
+++ b/src/database/factories/PaymentTransactionFactory.php
@@ -4,7 +4,6 @@ namespace rkujawa\LaravelPaymentGateway\Database\Factories;
 
 use Illuminate\Database\Eloquent\Factories\Factory;
 use rkujawa\LaravelPaymentGateway\Models\PaymentMethod;
-use rkujawa\LaravelPaymentGateway\Models\PaymentProvider;
 use rkujawa\LaravelPaymentGateway\Models\PaymentTransaction;
 
 class PaymentTransactionFactory extends Factory


### PR DESCRIPTION
### **What does this PR do?** :robot:

- 🖊️  Renames the `LaravelPaymentGateway::class` to `PaymentGateway::class`.
- ♻️  Swaps the `PaymentGateway::class` interface injection for the new `PaymentGateway::class` (including the `Payment` facade).
- 🔧  Fixes the `PaymentProcesser::class` interface typo (`PaymentProcessor::class`).
- ☠️  Removes dead some dead code.

### **How should this be tested?** :microscope:

1. Attempt to use dependency injection on the `\rkujawa\LaravelPaymentGateway\PaymentGateway::class` and utilize the provider and merchant management on the class. 
2. Do the same with the facade to make sure it works as expected.

### **Any background context you would like to provide?** :construction:
The reason the dependency injection should be referencing the `PaymentGateway::class` class instead of the interface is to help the code editor or ide to recognize the existing properties and/or functions.

### **Any questions or suggestions?** :thought_balloon:
I would also suggest looking into the namespace conventions for this package:

- I believe that the 'r' in 'rkujawa' should be capitalized.
- Look into renaming the `LaravelPaymentGateway` portion of the namespace to something shorter like `Payments`.
