### PR TITLE
Add type relation to PaymentMethod model

### DIFF
--- a/src/Models/PaymentMethod.php
+++ b/src/Models/PaymentMethod.php
@@ -71,6 +71,11 @@ class PaymentMethod extends Model
         return $this->belongsTo(config('payment.models.' . Wallet::class, Wallet::class));
     }
 
+    public function type()
+    {
+        return $this->belongsTo(config('payment.models.' . PaymentType::class, PaymentType::class));
+    }
+
     public function transactions()
     {
         return $this->hasMany(config('payment.models.' . PaymentTransaction::class, PaymentTransaction::class));


### PR DESCRIPTION
### **What does this PR do?** :robot:
It adds the forgotten relationship between the `PaymentMethod::class` model and the `PaymentType::class` model.