### PR TITLE
Laravel firstOr() bug workaround

### DIFF
--- a/src/Models/PaymentMerchant.php
+++ b/src/Models/PaymentMerchant.php
@@ -24,7 +24,7 @@ class PaymentMerchant extends Model
 
     public function providers()
     {
-        return $this->belongsToMany(config('payment.models.' . PaymentProvider::class, PaymentProvider::class), 'payment_merchant_provider', 'merchant_id', 'provider_id');
+        return $this->belongsToMany(config('payment.models.' . PaymentProvider::class, PaymentProvider::class), 'payment_merchant_provider', 'merchant_id', 'provider_id')->withPivot(['is_default'])->withTimestamps();
     }
 
     public function wallets()

--- a/src/Models/PaymentProvider.php
+++ b/src/Models/PaymentProvider.php
@@ -24,7 +24,7 @@ class PaymentProvider extends Model
 
     public function merchants()
     {
-        return $this->belongsToMany(config('payment.models.' . PaymentMerchant::class, PaymentMerchant::class), 'payment_merchant_provider', 'provider_id', 'merchant_id');
+        return $this->belongsToMany(config('payment.models.' . PaymentMerchant::class, PaymentMerchant::class), 'payment_merchant_provider', 'provider_id', 'merchant_id')->withPivot(['is_default'])->withTimestamps();
     }
 
     public function wallets()


### PR DESCRIPTION
### **What does this PR do?** :robot:

- Prevents the use of `firstOr()` function on a `BelongsToMany::class` relationship.
- Adds pivot values to the merchant and provider model relationships.

### **How should this be tested?** :microscope:
You can `php artisan tinker` this functionality.
To test the `firstOr()` workaround you can attempt to create a `Wallet::class` model with `Wallet::factory()->create()`. If you had no payment merchant and providers, the first attempt on this will execute the `Or` part of the workaround and the second attempt will use an existing merchant and provider, which will execute the `first` part of the workaround.

### **Any background context you would like to provide?** :construction:
I also submitted a bug fix to [laravel/framework](https://github.com/laravel/framework) to get the `firstOr()` function working as expected on the `BelongsToMany::class` relation. ([#40828](https://github.com/laravel/framework/pull/40828))
