### PR TITLE
[1.x] Add option to route request based on `$paymentMethod`

### DIFF
--- a/src/Models/PaymentMethod.php
+++ b/src/Models/PaymentMethod.php
@@ -24,6 +24,13 @@ class PaymentMethod extends Model
     protected $appends = ['expiration_date'];
 
     /**
+     * The payment method's pre-configured gateway.
+     *
+     * @var \rkujawa\LaravelPaymentGateway\PaymentGateway
+     */
+    private $paymentGateway;
+
+    /**
      * Create a new factory instance for the model.
      *
      * @return \Illuminate\Database\Eloquent\Factories\Factory
@@ -91,25 +98,50 @@ class PaymentMethod extends Model
         return $this->exp_month . $separator . $this->exp_year;
     }
 
-    public function getPaymentGatewayAttribute()
+    /**
+     * Retrieve the payment method's configured gateway.
+     *
+     * @return \rkujawa\LaravelPaymentGateway\PaymentGateway
+     */
+    public function getGatewayAttribute()
     {
-        return (new PaymentGateway)
-            ->provider($this->wallet->provider)
-            ->merchant($this->wallet->merchant);
+        if (! isset($this->paymentGateway)) {
+            $this->paymentGateway = (new PaymentGateway)
+                ->provider($this->wallet->provider)
+                ->merchant($this->wallet->merchant);
+        }
+        
+        return $this->paymentGateway;
     }
 
-    public function makeShowRequest()
+    /**
+     * Request the payment method details from the provider.
+     *
+     * @return \rkujawa\LaravelPaymentGateway\Contracts\PaymentManagerResponse
+     */
+    public function requestDetails()
     {
-        return $this->paymentGateway->getPaymentMethod($this);
+        return $this->gateway->getPaymentMethod($this);
     }
 
-    public function makeUpdateRequest($data)
+    /**
+     * Request the provider to update the payment method's details.
+     *
+     * @param array|mixed $data
+     * @return \rkujawa\LaravelPaymentGateway\Contracts\PaymentManagerResponse
+     */
+    public function requestUpdate($data)
     {
-        return $this->paymentGateway->updatePaymentMethod($this, $data);
+        return $this->gateway->updatePaymentMethod($this, $data);
     }
 
-    public function makeRemoveRequest()
+    /**
+     * Request the provider to remove the payment method from their system.
+     *
+     * @return \rkujawa\LaravelPaymentGateway\Contracts\PaymentManagerResponse
+     */
+    public function requestRemoval()
     {
-        return $this->paymentGateway->deletePaymentMethod($this);
+        return $this->gateway->deletePaymentMethod($this);
     }
 }

--- a/src/Models/PaymentMethod.php
+++ b/src/Models/PaymentMethod.php
@@ -6,6 +6,7 @@ use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\SoftDeletes;
 use rkujawa\LaravelPaymentGateway\Database\Factories\PaymentMethodFactory;
+use rkujawa\LaravelPaymentGateway\PaymentGateway;
 
 class PaymentMethod extends Model
 {
@@ -88,5 +89,27 @@ class PaymentMethod extends Model
         }
 
         return $this->exp_month . $separator . $this->exp_year;
+    }
+
+    public function getPaymentGatewayAttribute()
+    {
+        return (new PaymentGateway)
+            ->provider($this->wallet->provider)
+            ->merchant($this->wallet->merchant);
+    }
+
+    public function makeShowRequest()
+    {
+        return $this->paymentGateway->getPaymentMethod($this);
+    }
+
+    public function makeUpdateRequest($data)
+    {
+        return $this->paymentGateway->updatePaymentMethod($this, $data);
+    }
+
+    public function makeRemoveRequest()
+    {
+        return $this->paymentGateway->deletePaymentMethod($this);
     }
 }


### PR DESCRIPTION
### **What does this PR do?** :robot:

- It sets provider and merchant based on the `$paymentMethod` model's configuration and routes request through a `new PaymentGateway` object to not affect the singleton.
- Moves the provider-merchant support to a new function to allow `null` merchant to be passed into the provider's gateway class (in case the default merchant does not support the current provider).

### **Any background context you would like to provide?** :construction:
The reason for allowing a `null` merchant is to prevent an exception from being thrown when the developer doesn't care about setting up a merchant since in most cases this package will be used for simple projects that only require 1 provider & merchant to process payments.

### **Any questions or suggestions?** :thought_balloon:
This is not exactly the solution requested in the issue, but from my POV it is a better solution to not add too much complexity onto the `PaymentGateway::class`.

The `charge()` function could not be implemented here due to it not accepting an existing payment method by default, let's make this update in v2.x.

### **Does this relate to any issue?** :link:
Closes #53 
