### PR TITLE
[1.x] Add `merchant_id` column to `payment_transactions` table

### DIFF
--- a/src/Models/PaymentTransaction.php
+++ b/src/Models/PaymentTransaction.php
@@ -34,4 +34,9 @@ class PaymentTransaction extends Model
     {
         return $this->belongsTo(config('payment.models.' . PaymentProvider::class, PaymentProvider::class));
     }
+
+    public function merchant()
+    {
+        return $this->belongsTo(config('payment.models.' . PaymentMerchant::class, PaymentMerchant::class));
+    }
 }

--- a/src/database/factories/PaymentMethodFactory.php
+++ b/src/database/factories/PaymentMethodFactory.php
@@ -23,26 +23,42 @@ class PaymentMethodFactory extends Factory
      */
     public function definition()
     {
-        $wallet = Wallet::inRandomOrder()->firstOr(function () {
-            return Wallet::factory()->create();
-        });
-
-        $type = PaymentType::inRandomOrder()->firstOr(function () {
-            return PaymentType::factory()->create();
-        });
-
         $exp['year'] = (string) $this->faker->numberBetween(now()->year, now()->year + 11);
         $exp['month'] = (string) $this->faker->numberBetween($exp['year'] === now()->year ? now()->month : 1, 12);
 
         return [
-            'wallet_id' => $wallet->id,
             'token' => $this->faker->uuid(),
             'first_name' => $this->faker->firstName(),
             'last_name' => $this->faker->lastName(),
             'last_digits' => $this->faker->numerify('####'),
             'exp_month' => str_pad($exp['month'], 2, '0', STR_PAD_LEFT),
             'exp_year' => $exp['year'],
-            'type_id' => $type->id,
         ];
+    }
+
+    /**
+     * Configure the model factory.
+     *
+     * @return $this
+     */
+    public function configure()
+    {
+        return $this->afterMaking(function (PaymentMethod $paymentMethod) {
+            if(is_null($paymentMethod->wallet_id)) {
+                $wallet = Wallet::inRandomOrder()->firstOr(function () {
+                    return Wallet::factory()->create();
+                });
+
+                $paymentMethod->wallet_id = $wallet->id;
+            }
+
+            if (is_null($paymentMethod->type_id)) {
+                $type = PaymentType::inRandomOrder()->firstOr(function () {
+                    return PaymentType::factory()->create();
+                });
+
+                $paymentMethod->type_id = $type->id;
+            }
+        });
     }
 }

--- a/src/database/factories/PaymentRefundFactory.php
+++ b/src/database/factories/PaymentRefundFactory.php
@@ -23,18 +23,32 @@ class PaymentRefundFactory extends Factory
      */
     public function definition()
     {
-        $paymentTransaction = PaymentTransaction::inRandomOrder()->firstOr(function () {
-            return PaymentTransaction::factory()->create();
-        });
-
         return [
             'reference_id' => $this->faker->uuid(),
-            'transaction_id' => $paymentTransaction->id,
-            'amount_cents' => $this->faker->numberBetween(1, 999) * 100,
             'currency' => $this->faker->currencyCode(),
             'type' => $this->faker->randomElement([PaymentRefund::VOID, PaymentRefund::REFUND]),
             'status_code' => 69, // TODO: Determine the status codes.
             'payload' => [],
         ];
+    }
+
+    /**
+     * Configure the model factory.
+     *
+     * @return $this
+     */
+    public function configure()
+    {
+        return $this->afterMaking(function (PaymentRefund $refund) {
+            if (is_null($refund->transaction_id)) {
+                $transaction = PaymentTransaction::factory()->create();
+
+                $refund->transaction_id = $transaction->id;
+            }
+
+            if (is_null($refund->amount_cents)) {
+                $refund->amount_cents = $refund->transaction->amount_cents;
+            }
+        });
     }
 }

--- a/src/database/factories/WalletFactory.php
+++ b/src/database/factories/WalletFactory.php
@@ -36,28 +36,28 @@ class WalletFactory extends Factory
     public function configure()
     {
         return $this->afterMaking(function (Wallet $wallet) {
-            if (is_null($wallet->merchant_id)) {
-                $merchant = PaymentMerchant::whereHas('providers', function ($query) use ($wallet) {
-                    $query->where('payment_providers.id', $wallet->provider_id);
-                })->inRandomOrder()->firstOr(function () {
-                    return PaymentMerchant::factory()->create();
-                });
-
-                $wallet->merchant_id = $merchant->id;
-            }
-
             if (is_null($wallet->provider_id)) {
                 $provider = PaymentProvider::whereHas('merchants', function ($query) use ($wallet) {
                     $query->where('payment_merchants.id', $wallet->merchant_id);
-                })->inRandomOrder()->firstOr(function () use ($wallet) {
-                    $provider = PaymentProvider::factory()->create();
-        
-                    $provider->merchants()->attach($wallet->merchant_id, ['is_default' => true]);
-        
-                    return $provider;
+                })->inRandomOrder()->firstOr(function () {
+                    return PaymentProvider::factory()->create();
                 });
 
                 $wallet->provider_id = $provider->id;
+            }
+
+            if (is_null($wallet->merchant_id)) {
+                $merchant = PaymentMerchant::whereHas('providers', function ($query) use ($wallet) {
+                    $query->where('payment_providers.id', $wallet->provider_id);
+                })->inRandomOrder()->firstOr(function () use ($wallet) {
+                    $merchant = PaymentMerchant::factory()->create();
+
+                    $merchant->providers()->attach($wallet->provider_id, ['is_default' => true]);
+
+                    return $merchant;
+                });
+
+                $wallet->merchant_id = $merchant->id;
             }
         });
     }

--- a/src/database/migrations/2021_01_01_000000_create_base_payment_tables.php
+++ b/src/database/migrations/2021_01_01_000000_create_base_payment_tables.php
@@ -80,6 +80,7 @@ class CreateBasePaymentTables extends Migration
         Schema::create('payment_transactions', function (Blueprint $table) {
             $table->bigIncrements('id');
             $table->unsignedSmallInteger('provider_id');
+            $table->unsignedMediumInteger('merchant_id');
             $table->string('reference_id');
             $table->unsignedInteger('amount_cents');
             $table->char('currency', 3)->default('USD');
@@ -90,6 +91,7 @@ class CreateBasePaymentTables extends Migration
             $table->timestamps();
 
             $table->foreign('provider_id')->references('id')->on('payment_providers');
+            $table->foreign('merchant_id')->references('id')->on('payment_merchants');
             $table->foreign('payment_method_id')->references('id')->on('payment_methods')->onDelete('set null');
         });
 


### PR DESCRIPTION
### **What does this PR do?** :robot:

- Adds the `merchant_id` column to the `payment_transactions` table.
- Adds the `merchant()` relationship to the `PaymentTransaction::class` model.
- Optimizes model factories that create other factories.

### **Any background context you would like to provide?** :construction:
This PR possibly introduces breaking changes if the developer was using the `PaymentTransaction::factory()`, but those breaking changes only apply to 'non-production' environments (hopefully). This is why I am directing this to `1.x`.

### **Does this relate to any issue?** :link:
Closes #56 
