### PR TITLE
[2.x] Do not allow null merchant into gateway.

### DIFF
--- a/src/Console/stubs/payment-gateway.stub
+++ b/src/Console/stubs/payment-gateway.stub
@@ -9,9 +9,9 @@ class {{ name }}PaymentGateway
     /**
      * Set the gateway $client
      *
-     * @param  \rkujawa\LaravelPaymentGateway\Models\PaymentMerchant|null $merchant
+     * @param  \rkujawa\LaravelPaymentGateway\Models\PaymentMerchant $merchant
      */
-    public function __construct($merchant = null)
+    public function __construct($merchant)
     {
         // Set the http client.
     }

--- a/src/PaymentService.php
+++ b/src/PaymentService.php
@@ -95,12 +95,10 @@ class PaymentService
         return $provider;
     }
 
-    private function ensureMerchantIsSupportedByProvider($nullable = false)
+    private function ensureMerchantIsSupportedByProvider()
     {
         if ($this->merchant->providers->doesntContain('id', $this->getProvider()->id)) {
-            return $nullable
-                ? null
-                : throw new Exception('The ' . $this->getProvider()->name . ' provider does not support the ' . $this->merchant->name . ' merchant.');
+            throw new Exception('The ' . $this->getProvider()->name . ' provider does not support the ' . $this->merchant->name . ' merchant.');
         }
 
         return $this->merchant;
@@ -243,6 +241,6 @@ class PaymentService
             throw new Exception('The ' . $gateway . '::class does not exist, if you moved or renamed your ' . $service . ' service class, please specify it in the payment.php config.');
         }
 
-        return new $gateway($this->ensureMerchantIsSupportedByProvider(true));
+        return new $gateway($this->ensureMerchantIsSupportedByProvider());
     }
 }


### PR DESCRIPTION
### **What does this PR do?** :robot:

- Prevents a `null` merchant from being passed into the payment gateway constructor.
- Updates the stub that is generated for the payment gateway to not allow `null` merchants.
