### PR TITLE
[2.x] Replace `payment_methods` table specific type columns to a single `json('details')` column to support any type. 

### DIFF
--- a/src/Models/PaymentMerchant.php
+++ b/src/Models/PaymentMerchant.php
@@ -10,6 +10,11 @@ class PaymentMerchant extends Model
 {
     use HasFactory;
 
+    /**
+     * The attributes that aren't mass assignable.
+     *
+     * @var string[]|bool
+     */
     protected $guarded = ['id'];
 
     /**
@@ -22,21 +27,42 @@ class PaymentMerchant extends Model
         return PaymentMerchantFactory::new();
     }
 
+    /**
+     * Get the providers that the merchant belongs to.
+     *
+     * @return \Illuminate\Database\Eloquent\Relations\BelongsToMany
+     */
     public function providers()
     {
         return $this->belongsToMany(config('payment.models.' . PaymentProvider::class, PaymentProvider::class), 'payment_merchant_provider', 'merchant_id', 'provider_id')->withPivot(['is_default'])->withTimestamps();
     }
 
+    /**
+     * Get the merchant's wallets.
+     *
+     * @return \Illuminate\Database\Eloquent\Relations\HasMany
+     */
     public function wallets()
     {
         return $this->hasMany(config('payment.models.' . Wallet::class, Wallet::class), 'merchant_id');
     }
 
+    /**
+     * Get the payment methods stored under the merchant's account.
+     *
+     * @return \Illuminate\Database\Eloquent\Relations\HasManyThrough
+     */
     public function payment_methods()
     {
         return $this->hasManyThrough(config('payment.models.' . PaymentMethod::class, PaymentMethod::class), config('payment.models.' . Wallet::class, Wallet::class), 'merchant_id');
     }
 
+    /**
+     * Generate a slug based off a string that follows a set of rules to make it valid.
+     *
+     * @param string $name
+     * @return string
+     */
     public static function slugify($name)
     {
         return preg_replace('/[^a-z0-9]+/i', '_', trim(strtolower($name)));

--- a/src/Models/PaymentMethod.php
+++ b/src/Models/PaymentMethod.php
@@ -8,19 +8,36 @@ use Illuminate\Database\Eloquent\SoftDeletes;
 use rkujawa\LaravelPaymentGateway\Database\Factories\PaymentMethodFactory;
 use rkujawa\LaravelPaymentGateway\Models\Traits\PaymentMethodRequests;
 
-=
-
 class PaymentMethod extends Model
 {
     use HasFactory;
     use SoftDeletes;
     use PaymentMethodRequests;
 
+    /**
+     * The attributes that aren't mass assignable.
+     *
+     * @var string[]|bool
+     */
     protected $guarded = ['id'];
 
+    /**
+     * The attributes that should be hidden for serialization.
+     *
+     * @var array
+     */
     protected $hidden = [
         'token',
         'details',
+    ];
+
+    /**
+     * The attributes that should be cast.
+     *
+     * @var array
+     */
+    protected $casts = [
+        'details' => 'array',
     ];
 
     /**
@@ -33,26 +50,51 @@ class PaymentMethod extends Model
         return PaymentMethodFactory::new();
     }
 
+    /**
+     * Get the payment method's provider.
+     *
+     * @return \rkujawa\LaravelPaymentGateway\Models\PaymentProvider
+     */
     public function getProviderAttribute()
     {
         return $this->wallet->provider;
     }
 
+    /**
+     * Get the payment method's merchant.
+     *
+     * @return \rkujawa\LaravelPaymentGateway\Models\PaymentMerchant
+     */
     public function getMerchantAttribute()
     {
         return $this->wallet->merchant;
     }
 
+    /**
+     * Get the wallet the payment method belongs to.
+     *
+     * @return \Illuminate\Database\Eloquent\Relations\BelongsTo
+     */
     public function wallet()
     {
         return $this->belongsTo(config('payment.models.' . Wallet::class, Wallet::class));
     }
 
+    /**
+     * Get the payment method's type
+     *
+     * @return \Illuminate\Database\Eloquent\Relations\BelongsTo
+     */
     public function type()
     {
         return $this->belongsTo(config('payment.models.' . PaymentType::class, PaymentType::class));
     }
 
+    /**
+     * Get the transactions that this payment method has triggered.
+     *
+     * @return void \Illuminate\Database\Eloquent\Relations\HasMany
+     */
     public function transactions()
     {
         return $this->hasMany(config('payment.models.' . PaymentTransaction::class, PaymentTransaction::class));

--- a/src/Models/PaymentProvider.php
+++ b/src/Models/PaymentProvider.php
@@ -10,6 +10,11 @@ class PaymentProvider extends Model
 {
     use HasFactory;
 
+    /**
+     * The attributes that aren't mass assignable.
+     *
+     * @var string[]|bool
+     */
     protected $guarded = ['id'];
 
     /**
@@ -22,21 +27,42 @@ class PaymentProvider extends Model
         return PaymentProviderFactory::new();
     }
 
+    /**
+     * Get the merchant's the provider supports.
+     *
+     * @return \Illuminate\Database\Eloquent\Relations\BelongsToMany
+     */
     public function merchants()
     {
         return $this->belongsToMany(config('payment.models.' . PaymentMerchant::class, PaymentMerchant::class), 'payment_merchant_provider', 'provider_id', 'merchant_id')->withPivot(['is_default'])->withTimestamps();
     }
 
+    /**
+     * Get the wallets the provider manages.
+     *
+     * @return \Illuminate\Database\Eloquent\Relations\HasMany
+     */
     public function wallets()
     {
         return $this->hasMany(config('payment.models.' . Wallet::class, Wallet::class), 'provider_id');
     }
 
+    /**
+     * Get the payment methods the provider manages.
+     *
+     * @return \\Illuminate\Database\Eloquent\Relations\HasManyThrough
+     */
     public function payment_methods()
     {
         return $this->hasManyThrough(config('payment.models.' . PaymentMethod::class, PaymentMethod::class), config('payment.models.' . Wallet::class, Wallet::class), 'provider_id');
     }
 
+    /**
+     * Generate a slug based off a string that follows a set of rules to make it valid.
+     *
+     * @param string $name
+     * @return string
+     */
     public static function slugify($name)
     {
         return preg_replace('/[^a-z0-9]+/i', '_', trim(strtolower($name)));

--- a/src/Models/PaymentRefund.php
+++ b/src/Models/PaymentRefund.php
@@ -13,17 +13,37 @@ class PaymentRefund extends Model
     const VOID = 'void';
     const REFUND = 'refund';
 
+    /**
+     * The attributes that aren't mass assignable.
+     *
+     * @var string[]|bool
+     */
     protected $guarded = ['id'];
 
+    /**
+     * The attributes that should be cast.
+     *
+     * @var array
+     */
     protected $casts = [
         'payload' => 'array',
     ];
 
+    /**
+     * Create a new factory instance for the model.
+     *
+     * @return \Illuminate\Database\Eloquent\Factories\Factory
+     */
     public static function newFactory()
     {
         return PaymentRefundFactory::new();
     }
 
+    /**
+     * Get the refund's original transaction.
+     *
+     * @return \Illuminate\Database\Eloquent\Relations\BelongsTo
+     */
     public function transaction()
     {
         return $this->belongsTo(config('payment.models.' . PaymentTransaction::class, PaymentTransaction::class));

--- a/src/Models/PaymentTransaction.php
+++ b/src/Models/PaymentTransaction.php
@@ -10,28 +10,58 @@ class PaymentTransaction extends Model
 {
     use HasFactory;
 
+    /**
+     * The attributes that aren't mass assignable.
+     *
+     * @var string[]|bool
+     */
     protected $guarded = ['id'];
 
+    /**
+     * The attributes that should be cast.
+     *
+     * @var array
+     */
     protected $casts = [
         'payload' => 'array',
         'references' => 'array',
     ];
 
+    /**
+     * Create a new factory instance for the model.
+     *
+     * @return \Illuminate\Database\Eloquent\Factories\Factory
+     */
     public static function newFactory()
     {
         return PaymentTransactionFactory::new();
     }
 
+    /**
+     * Get the payment method used for this transaction.
+     *
+     * @return \Illuminate\Database\Eloquent\Relations\BelongsTo
+     */
     public function paymentMethod()
     {
         return $this->belongsTo(config('payment.models.' . PaymentMethod::class, PaymentMethod::class));
     }
 
+    /**
+     * Get the provider the transaction belongs to.
+     *
+     * @return \Illuminate\Database\Eloquent\Relations\BelongsTo
+     */
     public function provider()
     {
         return $this->belongsTo(config('payment.models.' . PaymentProvider::class, PaymentProvider::class));
     }
 
+    /**
+     * Get the merchant the transaction belongs to.
+     *
+     * @return \Illuminate\Database\Eloquent\Relations\BelongsTo
+     */
     public function merchant()
     {
         return $this->belongsTo(config('payment.models.' . PaymentMerchant::class, PaymentMerchant::class));

--- a/src/Models/PaymentType.php
+++ b/src/Models/PaymentType.php
@@ -10,6 +10,11 @@ class PaymentType extends Model
 {
     use HasFactory;
 
+    /**
+     * The attributes that aren't mass assignable.
+     *
+     * @var string[]|bool
+     */
     protected $guarded = ['id'];
 
     /**
@@ -22,11 +27,22 @@ class PaymentType extends Model
         return PaymentTypeFactory::new();
     }
 
+    /**
+     * Get the payment methods that inherit this type.
+     *
+     * @return \Illuminate\Database\Eloquent\Relations\HasMany
+     */
     public function paymentMethods()
     {
         return $this->hasMany(config('payment.models.' . PaymentMethod::class, PaymentMethod::class), 'type_id');
     }
 
+    /**
+     * Generate a slug based off a string that follows a set of rules to make it valid.
+     *
+     * @param string $name
+     * @return string
+     */
     public static function slugify($name)
     {
         return preg_replace('/[^a-z0-9]+/i', '_', trim(strtolower($name)));

--- a/src/Models/Traits/ConfiguresPaymentGateway.php
+++ b/src/Models/Traits/ConfiguresPaymentGateway.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace rkujawa\LaravelPaymentGateway\Models\Traits;
+
+use rkujawa\LaravelPaymentGateway\PaymentGateway;
+
+trait ConfiguresPaymentGateway
+{
+    /**
+     * The payment method's pre-configured gateway.
+     *
+     * @var \rkujawa\LaravelPaymentGateway\PaymentGateway
+     */
+    private $paymentGateway;
+
+    /**
+     * Retrieve the payment method's configured gateway.
+     *
+     * @return \rkujawa\LaravelPaymentGateway\PaymentGateway
+     */
+    public function getGatewayAttribute()
+    {
+        if (! isset($this->paymentGateway)) {
+            $this->paymentGateway = (new PaymentGateway)
+                ->provider($this->provider)
+                ->merchant($this->merchant);
+        }
+
+        return $this->paymentGateway;
+    }
+}

--- a/src/Models/Traits/PaymentMethodRequests.php
+++ b/src/Models/Traits/PaymentMethodRequests.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace rkujawa\LaravelPaymentGateway\Models\Traits;
+
+trait PaymentMethodRequests
+{
+    use ConfiguresPaymentGateway;
+
+    /**
+     * Request the payment method details from the provider.
+     *
+     * @return \rkujawa\LaravelPaymentGateway\Contracts\PaymentResponse
+     */
+    public function requestDetails()
+    {
+        return $this->gateway->getPaymentMethod($this);
+    }
+
+    /**
+     * Request the provider to update the payment method's details.
+     *
+     * @param array|mixed $data
+     * @return \rkujawa\LaravelPaymentGateway\Contracts\PaymentResponse
+     */
+    public function requestUpdate($data)
+    {
+        return $this->gateway->updatePaymentMethod($this, $data);
+    }
+
+    /**
+     * Request the provider to remove the payment method from their system.
+     *
+     * @return \rkujawa\LaravelPaymentGateway\Contracts\PaymentResponse
+     */
+    public function requestRemoval()
+    {
+        return $this->gateway->removePaymentMethod($this);
+    }
+
+    /**
+     * Request authorization for a payment.
+     *
+     * @param array|mixed $data
+     * @return \rkujawa\LaravelPaymentGateway\Contracts\PaymentResponse
+     */
+    public function authorize($data)
+    {
+        return $this->gateway->authorize($data, $this);
+    }
+
+    /**
+     * Request authorization for a payment and capture it.
+     *
+     * @param array|mixed $data
+     * @return \rkujawa\LaravelPaymentGateway\Contracts\PaymentResponse
+     */
+    public function authorizeAndCapture($data)
+    {
+        return $this->gateway->authorizeAndCapture($data, $this);
+    }
+}

--- a/src/Models/Traits/WalletRequests.php
+++ b/src/Models/Traits/WalletRequests.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace rkujawa\LaravelPaymentGateway\Models\Traits;
+
+trait WalletRequests
+{
+    use ConfiguresPaymentGateway;
+
+    /**
+     * Request the wallet details from the provider.
+     *
+     * @return \rkujawa\LaravelPaymentGateway\Contracts\PaymentResponse
+     */
+    public function requestDetails()
+    {
+        $this->gateway->getWallet($this);
+    }
+}

--- a/src/Models/Wallet.php
+++ b/src/Models/Wallet.php
@@ -12,8 +12,18 @@ class Wallet extends Model
     use HasFactory;
     use WalletRequests;
 
+    /**
+     * The attributes that aren't mass assignable.
+     *
+     * @var string[]|bool
+     */
     protected $guarded = ['id'];
 
+    /**
+     * The attributes that should be hidden for serialization.
+     *
+     * @var array
+     */
     protected $hidden = ['token'];
 
     /**
@@ -26,21 +36,41 @@ class Wallet extends Model
         return WalletFactory::new();
     }
 
+    /**
+     * Get the entity model that this wallet belongs to.
+     *
+     * @return \Illuminate\Database\Eloquent\Relations\MorphTo
+     */
     public function billable()
     {
         return $this->morphTo();
     }
 
+    /**
+     * Get the provider the wallet belongs to.
+     *
+     * @return \Illuminate\Database\Eloquent\Relations\BelongsTo
+     */
     public function provider()
     {
         return $this->belongsTo(config('payment.models.' . PaymentProvider::class, PaymentProvider::class));
     }
 
+    /**
+     * Get the merchant the wallet belongs to.
+     *
+     * @return \Illuminate\Database\Eloquent\Relations\BelongsTo
+     */
     public function merchant()
     {
         return $this->belongsTo(config('payment.models.' . PaymentMerchant::class, PaymentMerchant::class));
     }
 
+    /**
+     * Get the wallet's payment methods.
+     *
+     * @return \Illuminate\Database\Eloquent\Relations\HasMany
+     */
     public function paymentMethods()
     {
         return $this->hasMany(config('payment.models.' . PaymentMethod::class, PaymentMethod::class));

--- a/src/Models/Wallet.php
+++ b/src/Models/Wallet.php
@@ -5,13 +5,15 @@ namespace rkujawa\LaravelPaymentGateway\Models;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use rkujawa\LaravelPaymentGateway\Database\Factories\WalletFactory;
+use rkujawa\LaravelPaymentGateway\Models\Traits\WalletRequests;
 
 class Wallet extends Model
 {
     use HasFactory;
+    use WalletRequests;
 
     protected $guarded = ['id'];
-    
+
     protected $hidden = ['token'];
 
     /**
@@ -42,10 +44,5 @@ class Wallet extends Model
     public function paymentMethods()
     {
         return $this->hasMany(config('payment.models.' . PaymentMethod::class, PaymentMethod::class));
-    }
-
-    public static function findByToken(string $token)
-    {
-        return self::where('token', $token)->first();
     }
 }

--- a/src/database/migrations/2021_01_01_000000_create_base_payment_tables.php
+++ b/src/database/migrations/2021_01_01_000000_create_base_payment_tables.php
@@ -64,12 +64,8 @@ class CreateBasePaymentTables extends Migration
             $table->bigIncrements('id');
             $table->unsignedBigInteger('wallet_id');
             $table->string('token', 255);
-            $table->string('first_name')->nullable();
-            $table->string('last_name')->nullable();
-            $table->char('last_digits', 4);
-            $table->char('exp_month', 2);
-            $table->char('exp_year', 4);
             $table->unsignedSmallInteger('type_id');
+            $table->json('details')->nullable();
             $table->timestamps();
             $table->softDeletes();
 


### PR DESCRIPTION
### **What does this PR do?** :robot:
- Updates the `payment_methods` table:
    - Removes
    ```
    $table->string('first_name')->nullable();
    $table->string('last_name')->nullable();
    $table->char('last_digits', 4);
    $table->char('exp_month', 2);
    $table->char('exp_year', 4);
    ```
    - Adds
    ```
    $table->json('details')->nullable();
    ```

- Updates the `PaymentMethod::class` model to support these changes.
- Refactors and adds some code in the `PaymentMethod::class` & `Wallet::class` models to make requests to the PSP via the gateway, based on what's coming in PR #66.
- Adds some missing DocBlocks in models.

### **Does this relate to any issue?** :link:
Closes #52 
Closes #67 
Prepares for #66 
