### PR TITLE
[2.x] Remove payload columns from transaction tables

### DIFF
--- a/src/database/migrations/2021_01_01_000000_create_base_payment_tables.php
+++ b/src/database/migrations/2021_01_01_000000_create_base_payment_tables.php
@@ -82,7 +82,6 @@ class CreateBasePaymentTables extends Migration
             $table->unsignedBigInteger('payment_method_id')->nullable();
             $table->unsignedSmallInteger('status_code');
             $table->json('details')->nullable();
-            $table->longText('payload')->nullable();
             $table->timestamps();
 
             $table->foreign('provider_id')->references('id')->on('payment_providers');
@@ -97,7 +96,6 @@ class CreateBasePaymentTables extends Migration
             $table->unsignedBigInteger('amount');
             $table->smallInteger('status_code');
             $table->json('details')->nullable();
-            $table->longText('payload')->nullable();
             $table->timestamps();
 
             $table->foreign('transaction_id')->references('id')->on('payment_transactions')->onDelete('cascade');


### PR DESCRIPTION
### **What does this PR do?** :robot:

- Removes `payload` column from `payment_transactions` & `payment_transaction_events` tables.
