### PR TITLE
[3.x] Stop enforcing payment migrations

### DIFF
--- a/src/PaymentServiceProvider.php
+++ b/src/PaymentServiceProvider.php
@@ -11,8 +11,6 @@ class PaymentServiceProvider extends ServiceProvider
 {
     public function boot()
     {
-        $this->loadMigrationsFrom(__DIR__.'/database/migrations');
-
         if ($this->app->runningInConsole()) {
             $this->vendorPublish();
             $this->commands([
@@ -30,7 +28,7 @@ class PaymentServiceProvider extends ServiceProvider
         ], 'payment-config');
 
         $this->publishes([
-            __DIR__ . '/database/migrations/2021_01_01_000000_create_base_payment_tables.php' => database_path('migrations/2021_01_01_000000_create_base_payment_tables.php'),
+            __DIR__ . '/database/migrations/2021_01_01_000000_create_base_payment_tables.php' => database_path('migrations/' . now()->format('Y_m_d_His') . '_create_base_payment_tables.php'),
         ], 'payment-migration');
     }
 

--- a/tests/CommandTestCase.php
+++ b/tests/CommandTestCase.php
@@ -6,20 +6,6 @@ use Illuminate\Filesystem\Filesystem;
 
 abstract class CommandTestCase extends TestCase
 {
-    /**
-     * Setup the test environment.
-     *
-     * @return void
-     */
-    protected function setUp(): void
-    {
-        parent::setUp();
-
-        (new Filesystem)->cleanDirectory(database_path('migrations'));
-
-        $this->artisan('migrate');
-    }
-
     protected function getArgumentQuestion($model)
     {
         return "What payment {$model} would you like to add?";

--- a/tests/GatewayTestCase.php
+++ b/tests/GatewayTestCase.php
@@ -31,8 +31,6 @@ abstract class GatewayTestCase extends TestCase
     {
         parent::setUp();
 
-        $this->artisan('migrate');
-
         Schema::create('users', function ($table) {
             $table->id();
             $table->string('email')->unique();
@@ -82,7 +80,7 @@ class TestPaymentGateway extends PaymentRequest
     {
         return new TestPaymentResponse([]);
     }
-    
+
     public function deletePaymentMethod(PaymentMethod $paymentMethod)
     {
         return new TestPaymentResponse([]);
@@ -184,7 +182,7 @@ class User extends Model implements Billable
 {
     use BillableTrait,
         HasFactory;
-    
+
     protected static function newFactory()
     {
         return UserFactory::new();

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -2,10 +2,27 @@
 
 namespace rkujawa\LaravelPaymentGateway\Tests;
 
+use Illuminate\Filesystem\Filesystem;
 use rkujawa\LaravelPaymentGateway\PaymentServiceProvider;
 
 abstract class TestCase extends \Orchestra\Testbench\TestCase
 {
+    /**
+     * Setup the test environment.
+     *
+     * @return void
+     */
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        (new Filesystem)->cleanDirectory(database_path('migrations'));
+
+        $this->artisan('vendor:publish', ['--tag' => 'payment-migration']);
+
+        $this->artisan('migrate');
+    }
+
     protected function getPackageProviders($app)
     {
         return [


### PR DESCRIPTION
### **What does this PR do?** :robot:
It stops the this packages migrations from being automatically executed when running `php artisan migrate`. You may still publish the migrations running `php artisan vendor:publish --tag=payment-migration`.

### **Does this relate to any issue?** :link:
Closes #84 
