### PR TITLE
[2.x] Add `test_mode` to prevent unnecessary calls to the PSP

### DIFF
--- a/src/PaymentRequest.php
+++ b/src/PaymentRequest.php
@@ -4,12 +4,13 @@ namespace rkujawa\LaravelPaymentGateway;
 
 use rkujawa\LaravelPaymentGateway\Contracts\PaymentRequestor;
 use rkujawa\LaravelPaymentGateway\Models\PaymentMerchant;
+use rkujawa\LaravelPaymentGateway\Models\PaymentProvider;
 use rkujawa\LaravelPaymentGateway\Traits\PaymentRequests;
 
 abstract class PaymentRequest implements PaymentRequestor
 {
     use PaymentRequests;
-    
+
     /**
      * The payment merchant.
      *
@@ -18,11 +19,20 @@ abstract class PaymentRequest implements PaymentRequestor
     protected $merchant;
 
     /**
-     * @param  \rkujawa\LaravelPaymentGateway\Models\PaymentMerchant|null $merchant
+     * The Payment provider.
+     *
+     * @var \rkujawa\LaravelPaymentGateway\Models\PaymentProvider
      */
-    public function __construct(PaymentMerchant $merchant = null)
+    protected $provider;
+
+    /**
+     * @param  \rkujawa\LaravelPaymentGateway\Models\PaymentMerchant|null $merchant
+     * @param  \rkujawa\LaravelPaymentGateway\Models\PaymentProvider|null $provider
+     */
+    public function __construct(PaymentMerchant $merchant = null, PaymentProvider $provider = null)
     {
         $this->merchant = $merchant;
+        $this->provider = $provider;
 
         $this->setUp();
     }

--- a/src/PaymentRequest.php
+++ b/src/PaymentRequest.php
@@ -4,7 +4,6 @@ namespace rkujawa\LaravelPaymentGateway;
 
 use rkujawa\LaravelPaymentGateway\Contracts\PaymentRequestor;
 use rkujawa\LaravelPaymentGateway\Models\PaymentMerchant;
-use rkujawa\LaravelPaymentGateway\Models\PaymentProvider;
 use rkujawa\LaravelPaymentGateway\Traits\PaymentRequests;
 
 abstract class PaymentRequest implements PaymentRequestor
@@ -19,20 +18,11 @@ abstract class PaymentRequest implements PaymentRequestor
     protected $merchant;
 
     /**
-     * The Payment provider.
-     *
-     * @var \rkujawa\LaravelPaymentGateway\Models\PaymentProvider
-     */
-    protected $provider;
-
-    /**
      * @param  \rkujawa\LaravelPaymentGateway\Models\PaymentMerchant|null $merchant
-     * @param  \rkujawa\LaravelPaymentGateway\Models\PaymentProvider|null $provider
      */
-    public function __construct(PaymentMerchant $merchant = null, PaymentProvider $provider = null)
+    public function __construct(PaymentMerchant $merchant = null)
     {
         $this->merchant = $merchant;
-        $this->provider = $provider;
 
         $this->setUp();
     }

--- a/src/PaymentService.php
+++ b/src/PaymentService.php
@@ -246,7 +246,6 @@ class PaymentService
             throw new Exception('The ' . $gateway . '::class does not exist.');
         }
 
-        // TODO [3.x]: $param[0] should be provider & $param[1] should be merchant.
-        return new $gateway($this->ensureMerchantIsSupportedByProvider(), $this->getProvider());
+        return new $gateway($this->ensureMerchantIsSupportedByProvider());
     }
 }

--- a/src/config/payment.php
+++ b/src/config/payment.php
@@ -19,6 +19,32 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Payment Test Mode
+    |--------------------------------------------------------------------------
+    |
+    | When set to true, it will pass the provider & merchant into the testing
+    | gateway so you can mock your requests as you wish. This is very
+    | usefull when you are running tests in a CI/CD environment.
+    |
+    */
+    'test_mode' => env('PAYMENT_TEST_MODE', false),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Payment Test Configuration
+    |--------------------------------------------------------------------------
+    |
+    | The following configurations will only be considered when test_mode
+    | is set to true. Here you may set any configurations needed in
+    | order to have your tests running smoothly.
+    |
+    */
+    'test' => [
+        'gateway' => \App\Services\Payment\TestPaymentGateway::class,
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
     | Payment Provider Configurations
     |--------------------------------------------------------------------------
     |
@@ -32,7 +58,7 @@ return [
         //     'gateway' => \App\Services\Payment\ExamplePaymentGateway::class,
         // ],
     ],
-    
+
     /*
     |--------------------------------------------------------------------------
     | Payment Models


### PR DESCRIPTION
### **What does this PR do?** :robot:
- Adds `'test_mode'` to `payment.php` config.
- Automatically injects a `TestPaymentGateway::class` to allow mocking of gateways.
- Updates the `php artisan payment:add-provider` command to generate the test gateway for us.

### **How should this be tested?** :microscope:
Start by running the `php artisan payment:add-provider --test` command to publish the `TestPaymentGateway::class`. Define a custom implementation of it & test it by setting the `config('payment.test_mode')` to `true`.

### **Does this relate to any issue?** :link:
Closes #18.
