### PR TITLE
[2.x] Add `payment:install` command.

### DIFF
--- a/src/Console/Commands/AddPaymentMerchant.php
+++ b/src/Console/Commands/AddPaymentMerchant.php
@@ -81,7 +81,7 @@ class AddPaymentMerchant extends Command
         $this->info('The migration to add ' . $this->name . ' payment merchant has been generated.');
 
         if ((! $this->option('skip-migration')) && $this->confirm('Would you like to run the migration?', true)) {
-            $this->call('migrate', ['--force']);
+            $this->call('migrate', ['--force' => true]);
         }
     }
 
@@ -98,7 +98,7 @@ class AddPaymentMerchant extends Command
         );
 
         $this->slug = PaymentMerchant::slugify(
-            $this->option('slug') ?? 
+            $this->option('slug') ??
             $this->ask("What slug would you like to use for the {$this->name} payment merchant?", PaymentMerchant::slugify($this->name))
         );
 

--- a/src/Console/Commands/AddPaymentProvider.php
+++ b/src/Console/Commands/AddPaymentProvider.php
@@ -71,12 +71,15 @@ class AddPaymentProvider extends Command
      */
     protected function setProperties()
     {
+        if ($this->option('test', false)) {
+            $this->name = 'Test';
+            $this->slug = 'test';
+
+            return;
+        }
+
         $this->name = trim(
-            $this->argument('provider') ?? (
-                $this->option('test', false)
-                    ? 'Test'
-                    : $this->ask('What payment provider would you like to add?')
-            )
+            $this->argument('provider') ?? $this->ask('What payment provider would you like to add?')
         );
 
         $this->slug = PaymentProvider::slugify(
@@ -108,7 +111,7 @@ class AddPaymentProvider extends Command
         $this->info('The migration to add ' . $this->name . ' payment provider has been generated.');
 
         if ((! $this->option('skip-migration')) && $this->confirm('Would you like to run the migration?', true)) {
-            $this->call('migrate', ['--force']);
+            $this->call('migrate', ['--force' => true]);
         }
     }
 }

--- a/src/Console/Commands/AddPaymentType.php
+++ b/src/Console/Commands/AddPaymentType.php
@@ -11,7 +11,7 @@ use rkujawa\LaravelPaymentGateway\Traits\GeneratesMigrations;
 class AddPaymentType extends Command
 {
     use GeneratesMigrations;
-    
+
     /**
      * The name and signature of the console command.
      *
@@ -72,7 +72,7 @@ class AddPaymentType extends Command
         $this->info('The migration to add ' . $this->name . ' payment type has been generated.');
 
         if ((! $this->option('skip-migration')) && $this->confirm('Would you like to run the migration?', true)) {
-            $this->call('migrate', ['--force']);
+            $this->call('migrate', ['--force' => true]);
         }
     }
 

--- a/src/Console/Commands/PaymentInstall.php
+++ b/src/Console/Commands/PaymentInstall.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace rkujawa\LaravelPaymentGateway\Console\Commands;
+
+use Illuminate\Console\Command;
+
+class PaymentInstall extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'payment:install';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Install and configure payments within your application.';
+
+    /**
+     * Execute the console command.
+     *
+     * @return void
+     */
+    public function handle()
+    {
+        $this->callSilent('vendor:publish', ['--provider' => 'rkujawa\LaravelPaymentGateway\PaymentServiceProvider']);
+
+        $this->call('payment:add-provider', ['--test' => true]);
+
+        do {
+            $this->call('payment:add-type', ['--skip-migration' => true]);
+        } while ($this->confirm('Would you like to add another payment type?', true));
+
+        $this->call('migrate', ['--force' => true]);
+
+        do {
+            $this->call('payment:add-provider', ['--skip-migration' => true]);
+        } while ($this->confirm('Would you like to add another payment provider?', true));
+
+        $this->call('migrate', ['--force' => true]);
+
+        do {
+            $this->call('payment:add-merchant', ['--skip-migration' => true]);
+        } while ($this->confirm('Would you like to add another payment merchant?', true));
+
+        $this->call('migrate', ['--force' => true]);
+    }
+}

--- a/src/PaymentServiceProvider.php
+++ b/src/PaymentServiceProvider.php
@@ -11,8 +11,6 @@ class PaymentServiceProvider extends ServiceProvider
 {
     public function boot()
     {
-        $this->loadMigrationsFrom(__DIR__.'/database/migrations');
-
         if ($this->app->runningInConsole()) {
             $this->vendorPublish();
             $this->commands([
@@ -30,7 +28,7 @@ class PaymentServiceProvider extends ServiceProvider
         ], 'payment-config');
 
         $this->publishes([
-            __DIR__ . '/database/migrations/2021_01_01_000000_create_base_payment_tables.php' => database_path('migrations/2021_01_01_000000_create_base_payment_tables.php'),
+            __DIR__ . '/database/migrations/2021_01_01_000000_create_base_payment_tables.php' => database_path('migrations/' . now()->format('Y_m_d_His') . '_create_base_payment_tables.php'),
         ], 'payment-migration');
     }
 

--- a/src/PaymentServiceProvider.php
+++ b/src/PaymentServiceProvider.php
@@ -6,6 +6,7 @@ use Illuminate\Support\ServiceProvider;
 use rkujawa\LaravelPaymentGateway\Console\Commands\AddPaymentMerchant;
 use rkujawa\LaravelPaymentGateway\Console\Commands\AddPaymentProvider;
 use rkujawa\LaravelPaymentGateway\Console\Commands\AddPaymentType;
+use rkujawa\LaravelPaymentGateway\Console\Commands\PaymentInstall;
 
 class PaymentServiceProvider extends ServiceProvider
 {
@@ -17,6 +18,7 @@ class PaymentServiceProvider extends ServiceProvider
                 AddPaymentType::class,
                 AddPaymentProvider::class,
                 AddPaymentMerchant::class,
+                PaymentInstall::class,
             ]);
         }
     }

--- a/tests/CommandTestCase.php
+++ b/tests/CommandTestCase.php
@@ -6,20 +6,6 @@ use Illuminate\Filesystem\Filesystem;
 
 abstract class CommandTestCase extends TestCase
 {
-    /**
-     * Setup the test environment.
-     *
-     * @return void
-     */
-    protected function setUp(): void
-    {
-        parent::setUp();
-
-        (new Filesystem)->cleanDirectory(database_path('migrations'));
-
-        $this->artisan('migrate');
-    }
-
     protected function getArgumentQuestion($model)
     {
         return "What payment {$model} would you like to add?";

--- a/tests/Feature/AddPaymentProviderCommandTest.php
+++ b/tests/Feature/AddPaymentProviderCommandTest.php
@@ -94,9 +94,7 @@ class AddPaymentProviderCommandTest extends CommandTestCase
             '--test' => true,
         ];
 
-        $this->artisan('payment:add-provider', $arguments)
-            ->expectsQuestion($this->getOptionQuestion('slug', 'provider', 'Test'), 'test');
-
+        $this->artisan('payment:add-provider', $arguments);
 
         $servicePath = app_path('Services/Payment');
 

--- a/tests/Feature/PaymentInstallCommandTest.php
+++ b/tests/Feature/PaymentInstallCommandTest.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace rkujawa\LaravelPaymentGateway\Tests;
+
+use rkujawa\LaravelPaymentGateway\Models\PaymentMerchant;
+use rkujawa\LaravelPaymentGateway\Models\PaymentProvider;
+use rkujawa\LaravelPaymentGateway\Models\PaymentType;
+
+class PaymentInstallCommandTest extends CommandTestCase
+{
+    /** @test */
+    public function payment_install_command_publishes_assets_and_generates_the_test_payment_gateway()
+    {
+        $type = PaymentType::factory()->make();
+        $provider = PaymentProvider::factory()->make();
+        $merchant = PaymentMerchant::factory()->make();
+
+        $this->artisan('payment:install')
+            ->expectsQuestion($this->getArgumentQuestion('type'), $type->name)
+            ->expectsQuestion($this->getOptionQuestion('display name', 'type', $type->name), $type->display_name)
+            ->expectsQuestion($this->getOptionQuestion('slug', 'type', $type->name), $type->slug)
+            ->expectsOutput($this->getMigrationOutput('type', $type->name))
+            ->expectsConfirmation('Would you like to add another payment type?')
+            ->expectsQuestion($this->getArgumentQuestion('provider'), $provider->name)
+            ->expectsQuestion($this->getOptionQuestion('slug', 'provider', $provider->name), $provider->slug)
+            ->expectsConfirmation('Would you like to add another payment provider?')
+            ->expectsQuestion($this->getArgumentQuestion('merchant'), $merchant->name)
+            ->expectsQuestion($this->getOptionQuestion('slug', 'merchant', $merchant->name), $merchant->slug)
+            ->expectsChoice(
+                "Which payment providers will the {$merchant->name} merchant be using? (First chosen will be default)",
+                [$provider->slug],
+                [$provider->slug]
+            )
+            ->expectsConfirmation('Would you like to add another payment merchant?');
+
+        $this->assertTrue(file_exists(config_path('payment.php')));
+        $this->assertTrue(file_exists(app_path('Services/Payment/TestPaymentGateway.php')));
+    }
+}

--- a/tests/GatewayTestCase.php
+++ b/tests/GatewayTestCase.php
@@ -31,8 +31,6 @@ abstract class GatewayTestCase extends TestCase
     {
         parent::setUp();
 
-        $this->artisan('migrate');
-
         Schema::create('users', function ($table) {
             $table->id();
             $table->string('email')->unique();
@@ -82,7 +80,7 @@ class TestPaymentGateway extends PaymentRequest
     {
         return new TestPaymentResponse([]);
     }
-    
+
     public function deletePaymentMethod(PaymentMethod $paymentMethod)
     {
         return new TestPaymentResponse([]);
@@ -184,7 +182,7 @@ class User extends Model implements Billable
 {
     use BillableTrait,
         HasFactory;
-    
+
     protected static function newFactory()
     {
         return UserFactory::new();

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -2,10 +2,27 @@
 
 namespace rkujawa\LaravelPaymentGateway\Tests;
 
+use Illuminate\Filesystem\Filesystem;
 use rkujawa\LaravelPaymentGateway\PaymentServiceProvider;
 
 abstract class TestCase extends \Orchestra\Testbench\TestCase
 {
+    /**
+     * Setup the test environment.
+     *
+     * @return void
+     */
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        (new Filesystem)->cleanDirectory(database_path('migrations'));
+
+        $this->artisan('vendor:publish', ['--tag' => 'payment-migration']);
+
+        $this->artisan('migrate');
+    }
+
     protected function getPackageProviders($app)
     {
         return [


### PR DESCRIPTION
### **What does this PR do?** :robot:
Adds a new artisan command to help get you started using this package, it:
- Publishes the `payment.php` config file.
- Generates a `TestPaymentGateway::class` & `TestPaymentResponse::class`.
- Runs the `php artisan payment:add-type` command in a loop until you decide you had enough.
- Runs the `php artisan payment:add-provider` command in a loop until you decide you had enough.
- Runs the `php artisan payment:add-merchant` command in a loop until you decide you had enough.
- Adds a test to make sure all the above works ☝🏼.

### **How should this be tested?** :microscope:
Run the `php artisan payment:install` command after a `composer require r-kujawa/laravel-payment-gateway` fresh install.

### **Does this relate to any issue?** :link:
Closes #28 
