### PR TITLE
[3.x] Multiple driver support

### DIFF
--- a/src/Contracts/Merchantable.php
+++ b/src/Contracts/Merchantable.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace rkujawa\LaravelPaymentGateway\Contracts;
+
+interface Merchantable
+{
+    /**
+     * Get the merchant's id.
+     *
+     * @return int
+     */
+    public function getId();
+
+    /**
+     * Get the merchant's slug.
+     *
+     * @return string
+     */
+    public function getSlug();
+}

--- a/src/Contracts/Providable.php
+++ b/src/Contracts/Providable.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace rkujawa\LaravelPaymentGateway\Contracts;
+
+interface Providable
+{
+    /**
+     * Get the provider's id.
+     *
+     * @return int
+     */
+    public function getId();
+
+    /**
+     * Get the provider's slug.
+     */
+    public function getSlug();
+}

--- a/src/DataTransferObjects/Merchant.php
+++ b/src/DataTransferObjects/Merchant.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace rkujawa\LaravelPaymentGateway\DataTransferObjects;
+
+use Illuminate\Support\Collection;
+use rkujawa\LaravelPaymentGateway\Contracts\Merchantable;
+use rkujawa\LaravelPaymentGateway\Traits\SimulateAttributes;
+
+class Merchant implements Merchantable
+{
+    use SimulateAttributes;
+
+    /**
+     * Collection of providers this merchant is supported by.
+     *
+     * @var \Illuminate\Support\Collection
+     */
+    public $providers;
+
+    public function __construct(array $data)
+    {
+        $this->attributes = $data;
+
+        $this->providers = (new Collection($data['providers'] ?? []))->map(function ($provider, $key) {
+            if (is_array($provider)) {
+                return array_merge(
+                    config('payment.providers.' . $key),
+                    $provider
+                );
+            }
+
+            return config('payment.providers.' . $provider);
+        });
+    }
+
+    /**
+     * Get the provider's id.
+     *
+     * @return int
+     */
+    public function getId()
+    {
+        return $this->attributes['id'];
+    }
+
+    /**
+     * Get the provider's slug.
+     *
+     * @return string
+     */
+    public function getSlug()
+    {
+        return $this->attributes['slug'];
+    }
+}

--- a/src/DataTransferObjects/Provider.php
+++ b/src/DataTransferObjects/Provider.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace rkujawa\LaravelPaymentGateway\DataTransferObjects;
+
+use rkujawa\LaravelPaymentGateway\Contracts\Providable;
+use rkujawa\LaravelPaymentGateway\Traits\SimulateAttributes;
+
+class Provider implements Providable
+{
+    use SimulateAttributes;
+
+    public function __construct(array $data)
+    {
+        $this->attributes = $data;
+    }
+
+    /**
+     * Get the provider's id.
+     *
+     * @return int
+     */
+    public function getId()
+    {
+        return $this->attributes['id'];
+    }
+
+    /**
+     * Get the provider's slug.
+     *
+     * @return string
+     */
+    public function getSlug()
+    {
+        return $this->attributes['slug'];
+    }
+}

--- a/src/Drivers/ConfigDriver.php
+++ b/src/Drivers/ConfigDriver.php
@@ -1,0 +1,114 @@
+<?php
+
+namespace rkujawa\LaravelPaymentGateway\Drivers;
+
+use rkujawa\LaravelPaymentGateway\Contracts\Merchantable;
+use rkujawa\LaravelPaymentGateway\DataTransferObjects\Merchant;
+use rkujawa\LaravelPaymentGateway\DataTransferObjects\Provider;
+use rkujawa\LaravelPaymentGateway\PaymentServiceDriver;
+
+class ConfigDriver extends PaymentServiceDriver
+{
+    /**
+     * Collection of the application'n payment providers.
+     *
+     * @var \Illuminate\Support\Collection
+     */
+    protected $providers;
+
+    /**
+     * Collection of the application's merchants.
+     *
+     * @var \Illuminate\Support\Collection
+     */
+    protected $merchants;
+
+
+    /**
+     * Collect the application's payment providers & merchants.
+     */
+    public function __construct()
+    {
+        $this->providers = collect(config('payment.providers'));
+        $this->merchants = collect(config('payment.merchants'));
+    }
+
+    /**
+     * Resolve the providable instance.
+     *
+     * @param \rkujawa\LaravelPaymentGateway\Contracts\Providable|string|int $provider
+     * @return \rkujawa\LaravelPaymentGateway\Contracts\Providable|null
+     */
+    public function resolveProvider($provider)
+    {
+        if ($provider instanceof Provider) {
+            return $provider;
+        }
+
+        if (is_null($provider = $this->providers->firstWhere(is_int($provider) ? 'id' : 'slug', $provider))) {
+            return null;
+        }
+
+        return new Provider($provider);
+    }
+
+    /**
+     * Get the default providable identifier (slug or id).
+     *
+     * @param \rkujawa\LaravelPaymentGateway\Contracts\Merchantable|null $merchant
+     * @return string|int
+     */
+    public function getDefaultProvider(Merchantable $merchant = null)
+    {
+        if (
+            ! $merchant instanceof Merchant ||
+            is_null($provider = $merchant->providers->search(function ($provider) { return $provider['is_default'] ?? false; }))
+        ) {
+            return parent::getDefaultProvider();
+        }
+
+        return config('payment.providers.' . $provider . '.id');
+    }
+
+    /**
+     * Resolve the merchantable intance.
+     *
+     * @param \rkujawa\LaravelPaymentGateway\Contracts\Merchantable|string|int $merchant
+     * @return \rkujawa\LaravelPaymentGateway\Contracts\Merchantable|null
+     */
+    public function resolveMerchant($merchant)
+    {
+        if ($merchant instanceof Merchant) {
+            return $merchant;
+        }
+
+        if (is_null($merchant = $this->merchants->firstWhere(is_int($merchant) ? 'id' : 'slug', $merchant))) {
+            return null;
+        }
+
+        return new Merchant($merchant);
+    }
+
+    /**
+     * Verify that the merchant is compatible with the provider.
+     *
+     * @param \rkujawa\LaravelPaymentGateway\Contracts\Merchantable
+     * @param \rkujawa\LaravelPaymentGateway\Contracts\Providable
+     * @return bool
+     */
+    public function check($merchant, $provider)
+    {
+        return $merchant->providers->contains('id', $provider->id);
+    }
+
+    /**
+     * Resolve the gateway class.
+     *
+     * @param \rkujawa\LaravelPaymentGateway\Contracts\Providable $provider
+     * @return string
+     */
+    public function resolveGatewayClass($provider)
+    {
+        return $provider->request_class;
+    }
+}

--- a/src/Drivers/DatabaseDriver.php
+++ b/src/Drivers/DatabaseDriver.php
@@ -1,0 +1,91 @@
+<?php
+
+namespace rkujawa\LaravelPaymentGateway\Drivers;
+
+use rkujawa\LaravelPaymentGateway\Contracts\Merchantable;
+use rkujawa\LaravelPaymentGateway\Models\PaymentMerchant;
+use rkujawa\LaravelPaymentGateway\Models\PaymentProvider;
+use rkujawa\LaravelPaymentGateway\PaymentServiceDriver;
+
+class DatabaseDriver extends PaymentServiceDriver
+{
+    /**
+     * Resolve the providable instance.
+     *
+     * @param \rkujawa\LaravelPaymentGateway\Contracts\Providable|string|int $provider
+     * @return \rkujawa\LaravelPaymentGateway\Contracts\Providable|null
+     */
+    public function resolveProvider($provider)
+    {
+        if (! $provider instanceof PaymentProvider) {
+            $provider = PaymentProvider::where('slug', $provider)->orWhere('id', $provider)->first();
+        }
+
+        if (is_null($provider) || (! $provider->exists)) {
+            return null;
+        }
+
+        return $provider;
+    }
+
+    /**
+     * Get the default providable identifier (slug or id).
+     *
+     * @param \rkujawa\LaravelPaymentGateway\Contracts\Merchantable|null $merchant
+     * @return string|int
+     */
+    public function getDefaultProvider(Merchantable $merchant = null)
+    {
+        if (! $merchant instanceof PaymentMerchant || is_null($provider = $merchant->providers()->wherePivot('is_default', true)->first())) {
+            return parent::getDefaultProvider();
+        }
+
+        return $provider;
+    }
+
+    /**
+     * Resolve the merchantable intance.
+     *
+     * @param \rkujawa\LaravelPaymentGateway\Contracts\Merchantable|string|int $merchant
+     * @return \rkujawa\LaravelPaymentGateway\Contracts\Merchantable|null
+     */
+    public function resolveMerchant($merchant)
+    {
+        if (! $merchant instanceof PaymentMerchant) {
+            $merchant = PaymentMerchant::where('slug', $merchant)->orWhere('id', $merchant)->first();
+        }
+
+        if (is_null($merchant) || (! $merchant->exists)) {
+            return null;
+        }
+
+        return $merchant;
+    }
+
+    /**
+     * Verify that the merchant is compatible with the provider.
+     *
+     * @param \rkujawa\LaravelPaymentGateway\Contracts\Merchantable
+     * @param \rkujawa\LaravelPaymentGateway\Contracts\Providable
+     * @return bool
+     */
+    public function check($merchant, $provider)
+    {
+        if (! $merchant->providers->contains($provider)) {
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * Resolve the gateway class.
+     *
+     * @param \rkujawa\LaravelPaymentGateway\Contracts\Providable $provider
+     * @return string
+     */
+    public function resolveGatewayClass($provider)
+    {
+        return $provider->request_class;
+    }
+}

--- a/src/Models/PaymentMerchant.php
+++ b/src/Models/PaymentMerchant.php
@@ -4,9 +4,10 @@ namespace rkujawa\LaravelPaymentGateway\Models;
 
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
+use rkujawa\LaravelPaymentGateway\Contracts\Merchantable;
 use rkujawa\LaravelPaymentGateway\Database\Factories\PaymentMerchantFactory;
 
-class PaymentMerchant extends Model
+class PaymentMerchant extends Model implements Merchantable
 {
     use HasFactory;
 
@@ -25,6 +26,26 @@ class PaymentMerchant extends Model
     protected static function newFactory()
     {
         return PaymentMerchantFactory::new();
+    }
+
+    /**
+     * Get the merchant's id.
+     *
+     * @return int
+     */
+    public function getId()
+    {
+        return $this->id;
+    }
+
+    /**
+     * Get the merchant's slug.
+     *
+     * @return string
+     */
+    public function getSlug()
+    {
+        return $this->slug;
     }
 
     /**

--- a/src/Models/PaymentProvider.php
+++ b/src/Models/PaymentProvider.php
@@ -4,9 +4,10 @@ namespace rkujawa\LaravelPaymentGateway\Models;
 
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
+use rkujawa\LaravelPaymentGateway\Contracts\Providable;
 use rkujawa\LaravelPaymentGateway\Database\Factories\PaymentProviderFactory;
 
-class PaymentProvider extends Model
+class PaymentProvider extends Model implements Providable
 {
     use HasFactory;
 
@@ -25,6 +26,26 @@ class PaymentProvider extends Model
     protected static function newFactory()
     {
         return PaymentProviderFactory::new();
+    }
+
+    /**
+     * Get the provider's id.
+     *
+     * @return int
+     */
+    public function getId()
+    {
+        return $this->id;
+    }
+
+    /**
+     * Get the provider's slug.
+     *
+     * @return string
+     */
+    public function getSlug()
+    {
+        return $this->slug;
     }
 
     /**

--- a/src/PaymentRequest.php
+++ b/src/PaymentRequest.php
@@ -2,35 +2,36 @@
 
 namespace rkujawa\LaravelPaymentGateway;
 
+use rkujawa\LaravelPaymentGateway\Contracts\Merchantable;
 use rkujawa\LaravelPaymentGateway\Contracts\PaymentRequestor;
-use rkujawa\LaravelPaymentGateway\Models\PaymentMerchant;
-use rkujawa\LaravelPaymentGateway\Models\PaymentProvider;
+use rkujawa\LaravelPaymentGateway\Contracts\Providable;
 use rkujawa\LaravelPaymentGateway\Traits\PaymentRequests;
 
 abstract class PaymentRequest implements PaymentRequestor
 {
     use PaymentRequests;
 
-    /**
-     * The payment merchant.
-     *
-     * @var \rkujawa\LaravelPaymentGateway\Models\PaymentMerchant
-     */
-    protected $merchant;
-
-    /**
+        /**
      * The Payment provider.
      *
-     * @var \rkujawa\LaravelPaymentGateway\Models\PaymentProvider
+     * @var \rkujawa\LaravelPaymentGateway\Contracts\Providable
      */
     protected $provider;
 
     /**
-     * @param  \rkujawa\LaravelPaymentGateway\Models\PaymentMerchant|null $merchant
-     * @param  \rkujawa\LaravelPaymentGateway\Models\PaymentProvider|null $provider
+     * The payment merchant.
+     *
+     * @var \rkujawa\LaravelPaymentGateway\Contracts\Merchantable
      */
-    public function __construct(PaymentMerchant $merchant = null, PaymentProvider $provider = null)
+    protected $merchant;
+
+    /**
+     * @param  \rkujawa\LaravelPaymentGateway\Contracts\Merchantable|null $merchant
+     * @param  \rkujawa\LaravelPaymentGateway\Contracts\Providable|null $provider
+     */
+    public function __construct(Merchantable $merchant = null, Providable $provider = null)
     {
+        // TODO: Can this really be null?
         $this->merchant = $merchant;
         $this->provider = $provider;
 

--- a/src/PaymentRequest.php
+++ b/src/PaymentRequest.php
@@ -11,8 +11,8 @@ abstract class PaymentRequest implements PaymentRequestor
 {
     use PaymentRequests;
 
-        /**
-     * The Payment provider.
+    /**
+     * The payment provider.
      *
      * @var \rkujawa\LaravelPaymentGateway\Contracts\Providable
      */
@@ -26,12 +26,11 @@ abstract class PaymentRequest implements PaymentRequestor
     protected $merchant;
 
     /**
-     * @param  \rkujawa\LaravelPaymentGateway\Contracts\Merchantable|null $merchant
-     * @param  \rkujawa\LaravelPaymentGateway\Contracts\Providable|null $provider
+     * @param  \rkujawa\LaravelPaymentGateway\Contracts\Merchantable $merchant
+     * @param  \rkujawa\LaravelPaymentGateway\Contracts\Providable $provider
      */
-    public function __construct(Merchantable $merchant = null, Providable $provider = null)
+    public function __construct(Merchantable $merchant, Providable $provider)
     {
-        // TODO: Can this really be null?
         $this->merchant = $merchant;
         $this->provider = $provider;
 

--- a/src/PaymentServiceDriver.php
+++ b/src/PaymentServiceDriver.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace rkujawa\LaravelPaymentGateway;
+
+use rkujawa\LaravelPaymentGateway\Contracts\Merchantable;
+use rkujawa\LaravelPaymentGateway\Contracts\Providable;
+
+abstract class PaymentServiceDriver
+{
+    /**
+     * Resolve the providable instance.
+     *
+     * @param \rkujawa\LaravelPaymentGateway\Contracts\Providable|string|int $provider
+     * @return \rkujawa\LaravelPaymentGateway\Contracts\Providable|null
+     */
+    abstract public function resolveProvider($provider);
+
+    /**
+     * Get the default providable identifier (slug or id).
+     *
+     * @param \rkujawa\LaravelPaymentGateway\Contracts\Merchantable|null $merchant
+     * @return string|int
+     */
+    public function getDefaultProvider(Merchantable $merchant = null)
+    {
+        return config('payment.defaults.provider');
+    }
+
+    /**
+     * Resolve the merchantable intance.
+     *
+     * @param \rkujawa\LaravelPaymentGateway\Contracts\Merchantable|string|int $merchant
+     * @return \rkujawa\LaravelPaymentGateway\Contracts\Merchantable|null
+     */
+    abstract public function resolveMerchant($merchant);
+
+    /**
+     * Get the default merchantable identifier (slug or id).
+     *
+     * @param \rkujawa\LaravelPaymentGateway\Contracts\Providable|null $provider
+     * @return string|int
+     */
+    public function getDefaultMerchant(Providable $provider = null)
+    {
+        return config('payment.defaults.merchant');
+    }
+
+    /**
+     * Verify that the merchant is compatible with the provider.
+     *
+     * @param \rkujawa\LaravelPaymentGateway\Contracts\Merchantable
+     * @param \rkujawa\LaravelPaymentGateway\Contracts\Providable
+     * @return bool
+     */
+    abstract public function check($merchant, $provider);
+
+    /**
+     * Resolve the gateway class.
+     *
+     * @param \rkujawa\LaravelPaymentGateway\Contracts\Providable $provider
+     * @return string
+     */
+    abstract public function resolveGatewayClass($provider);
+}

--- a/src/PaymentServiceProvider.php
+++ b/src/PaymentServiceProvider.php
@@ -24,7 +24,7 @@ class PaymentServiceProvider extends ServiceProvider
     protected function vendorPublish()
     {
         $this->publishes([
-            __DIR__ . '/config/payment.php' => config_path('payment.php'),
+            __DIR__ . '/stubs/config/payment.stub' => config_path('payment.php'),
         ], 'payment-config');
 
         $this->publishes([
@@ -37,5 +37,10 @@ class PaymentServiceProvider extends ServiceProvider
         $this->app->singleton(PaymentGateway::class, function ($app) {
             return new PaymentGateway();
         });
+
+        $this->mergeConfigFrom(
+            __DIR__ . '/config/payment.php',
+            'payment'
+        );
     }
 }

--- a/src/Traits/PaymentResponses.php
+++ b/src/Traits/PaymentResponses.php
@@ -2,6 +2,9 @@
 
 namespace rkujawa\LaravelPaymentGateway\Traits;
 
+use Exception;
+use RuntimeException;
+
 trait PaymentResponses
 {
     use ThrowsRuntimeException;
@@ -10,89 +13,138 @@ trait PaymentResponses
      * Maps details from the getWallet() response to the expected format.
      *
      * @return array|mixed
+     *
+     * @throws \RuntimeException|Exception
      */
     public function getWalletResponse()
     {
-        $this->throwRuntimeException(__FUNCTION__);
+        return $this->genericResponse(__FUNCTION__);
     }
 
     /**
      * Maps details from the getPaymentMethod() response to the expected format.
      *
      * @return array|mixed
+     *
+     * @throws \RuntimeException|Exception
      */
     public function getPaymentMethodResponse()
     {
-        $this->throwRuntimeException(__FUNCTION__);
+        return $this->genericResponse(__FUNCTION__);
     }
 
     /**
      * Maps details from the tokenizePaymentMethod() response to the expected format.
      *
      * @return array|mixed
+     *
+     * @throws \RuntimeException|Exception
      */
     public function tokenizePaymentMethodResponse()
     {
-        $this->throwRuntimeException(__FUNCTION__);
+        return $this->genericResponse(__FUNCTION__);
     }
 
     /**
      * Maps details from the updatePaymentMethod() response to the expected format.
      *
      * @return array|mixed
+     *
+     * @throws \RuntimeException|Exception
      */
     public function updatePaymentMethodResponse()
     {
-        $this->throwRuntimeException(__FUNCTION__);
+        return $this->genericResponse(__FUNCTION__);
     }
-    
+
     /**
      * Maps details from the deletePaymentMethod() response to the expected format.
      *
      * @return array|mixed
+     *
+     * @throws \RuntimeException|Exception
      */
     public function deletePaymentMethodResponse()
     {
-        $this->throwRuntimeException(__FUNCTION__);
+        return $this->genericResponse(__FUNCTION__);
     }
 
     /**
      * Maps details from the authorize() response to the expected format.
      *
      * @return array|mixed
+     *
+     * @throws \RuntimeException|Exception
      */
     public function authorizeResponse()
     {
-        $this->throwRuntimeException(__FUNCTION__);
+        return $this->genericResponse(__FUNCTION__);
     }
 
     /**
      * Maps details from the capture() response to the expected format.
      *
      * @return array|mixed
+     *
+     * @throws \RuntimeException|Exception
      */
     public function captureResponse()
     {
-        $this->throwRuntimeException(__FUNCTION__);
+        return $this->genericResponse(__FUNCTION__);
     }
 
     /**
      * Maps details from the void() response to the expected format.
      *
      * @return array|mixed
+     *
+     * @throws \RuntimeException|Exception
      */
     public function voidResponse()
     {
-        $this->throwRuntimeException(__FUNCTION__);
+        return $this->genericResponse(__FUNCTION__);
     }
 
     /**
      * Maps details from the refund() response to the expected format.
      *
      * @return array|mixed
+     *
+     * @throws \RuntimeException|Exception
      */
     public function refundResponse()
     {
-        $this->throwRuntimeException(__FUNCTION__);
+        return $this->genericResponse(__FUNCTION__);
+    }
+
+    /**
+     * Attempts to call the generic response method, else throws RuntimeException.
+     *
+     * @param string $function
+     * @return array|mixed
+     *
+     * @throws \RuntimeException|Exception
+     */
+    private function genericResponse($function)
+    {
+        try {
+            return $this->response();
+        } catch (Exception $e) {
+            if ($e instanceof RuntimeException) {
+                $this->throwRuntimeException($function);
+            }
+
+            throw($e);
+        }
+    }
+
+    /**
+     * The generic payment request response.
+     *
+     * @throws \RuntimeException
+     */
+    public function response()
+    {
+        return $this->throwRuntimeException(__FUNCTION__);
     }
 }

--- a/src/Traits/SimulateAttributes.php
+++ b/src/Traits/SimulateAttributes.php
@@ -6,6 +6,11 @@ use Illuminate\Support\Str;
 
 trait SimulateAttributes
 {
+    /**
+     * The magic attributes array.
+     *
+     * @var array
+     */
     protected array $attributes = [];
 
     /**

--- a/src/Traits/SimulateAttributes.php
+++ b/src/Traits/SimulateAttributes.php
@@ -6,40 +6,61 @@ use Illuminate\Support\Str;
 
 trait SimulateAttributes
 {
+    protected array $attributes = [];
+
     /**
-     * Executes when the class attribute you are trying to get is not found.
-     * Checks if a getter function is defined and excecutes, otherwise returns.
+     * Checks if a get method exists and excecutes, otherwise returns value from the $attributes array.
      *
-     * @param string $key The hidden attribute.
+     * @param string $key.
      * @return mixed
      */
     public function __get($key)
     {
-        $method = 'get' . Str::studly($key);
-
-        if (! method_exists(self::class, $method)) {
-            return;
+        if (! method_exists(self::class, $method = 'get' . Str::studly($key))) {
+            return $this->getAttribute($key);
         }
 
         return $this->$method();
     }
 
     /**
-     * Excecutes if attempting to set a value on an attribute that is not found.
-     * Checks if a setter function is defined and excecutes, otherwise returns.
+     * Checks if a set method exists and excecutes, otherwise sets value in the $attributes array.
      *
-     * @param string $key The hidden attribute.
+     * @param string $key
      * @param mixed $value
      * @return void
      */
     public function __set($key, $value): void
     {
-        $method = 'set' . Str::studly($key);
+        if (! method_exists(self::class, $method = 'set' . Str::studly($key))) {
+            $this->setAttribute($key, $value);
 
-        if (! method_exists(self::class, $method)) {
             return;
         }
 
         $this->$method($value);
+    }
+
+    /**
+     * Get an attribute from the $attributes array.
+     *
+     * @param string $key
+     * @return mixed
+     */
+    protected function getAttribute($key)
+    {
+        return $this->attributes[$key] ?? null;
+    }
+
+    /**
+     * Sets a value in the $attributes array.
+     *
+     * @param string $key
+     * @param mixed $value
+     * @return void
+     */
+    protected function setAttribute($key, $value)
+    {
+        $this->attributes[$key] = $value;
     }
 }

--- a/src/config/payment.php
+++ b/src/config/payment.php
@@ -4,22 +4,6 @@ return [
 
     /*
     |--------------------------------------------------------------------------
-    | Payment Defaults
-    |--------------------------------------------------------------------------
-    |
-    | This option controls the default payment "provider" for your application.
-    | You may set these defaults as required, you should set your primary payments
-    | provider here, as it will be the provider to be injected automatically.
-    |
-    */
-    'defaults' => [
-        'driver' => 'database',
-        'provider' => '',
-        'merchant' => '',
-    ],
-
-    /*
-    |--------------------------------------------------------------------------
     | Payment Test Mode
     |--------------------------------------------------------------------------
     |
@@ -28,21 +12,7 @@ return [
     | usefull when you are running tests in a CI/CD environment.
     |
     */
-    'test_mode' => env('PAYMENT_TEST_MODE', false),
-
-    /*
-    |--------------------------------------------------------------------------
-    | Payment Test Configuration
-    |--------------------------------------------------------------------------
-    |
-    | The following configurations will only be considered when test_mode
-    | is set to true. Here you may set any configurations needed in
-    | order to have your tests running smoothly.
-    |
-    */
-    'test' => [
-        'gateway' => \App\Services\Payment\TestPaymentGateway::class,
-    ],
+    'test_mode' => false,
 
     /*
     |--------------------------------------------------------------------------
@@ -55,38 +25,8 @@ return [
     |
     */
     'drivers' => [
+        'config' => \rkujawa\LaravelPaymentGateway\Drivers\ConfigDriver::class,
         'database' => \rkujawa\LaravelPaymentGateway\Drivers\DatabaseDriver::class,
     ],
-
-    /*
-    |--------------------------------------------------------------------------
-    | Payment Provider Configurations
-    |--------------------------------------------------------------------------
-    |
-    | Here you may provide the location of your provider's gateway implementation
-    | by specifying the 'gateway' key for each provider and mapping the class to
-    | it, you may also add any provider specific configuration you might have.
-    |
-    */
-    'providers' => [
-        // 'example' => [
-        //     'gateway' => \App\Services\Payment\ExamplePaymentGateway::class,
-        // ],
-    ],
-
-    /*
-    |--------------------------------------------------------------------------
-    | Payment Models
-    |--------------------------------------------------------------------------
-    |
-    | This option allows you to override the models to be used for managing payments.
-    | You may define your own models that extend the ones of the package in order to
-    | keep your relationships in sync with your own models.
-    |
-    */
-    // 'models' => [
-    //     \rkujawa\LaravelPaymentGateway\Models\PaymentMethod::class => \App\Models\Payment\PaymentMethod::class,
-    //     \rkujawa\LaravelPaymentGateway\Models\Wallet::class => \App\Models\Payment\Wallet::class,
-    // ],
 
 ];

--- a/src/config/payment.php
+++ b/src/config/payment.php
@@ -13,6 +13,7 @@ return [
     |
     */
     'defaults' => [
+        'driver' => 'database',
         'provider' => '',
         'merchant' => '',
     ],
@@ -41,6 +42,20 @@ return [
     */
     'test' => [
         'gateway' => \App\Services\Payment\TestPaymentGateway::class,
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Payment Service Drivers
+    |--------------------------------------------------------------------------
+    |
+    | You may register custom payment drivers and/or remove the default ones.
+    | Pleas enot that in order for the driver to be compatible it must extend
+    | the \rkujawa\LaravelPaymentGateway\PaymentServiceDriver::class.
+    |
+    */
+    'drivers' => [
+        'database' => \rkujawa\LaravelPaymentGateway\Drivers\DatabaseDriver::class,
     ],
 
     /*

--- a/src/config/payment.php
+++ b/src/config/payment.php
@@ -50,7 +50,7 @@ return [
     |--------------------------------------------------------------------------
     |
     | You may register custom payment drivers and/or remove the default ones.
-    | Pleas enot that in order for the driver to be compatible it must extend
+    | Please note that in order for the driver to be compatible it must extend
     | the \rkujawa\LaravelPaymentGateway\PaymentServiceDriver::class.
     |
     */

--- a/src/database/factories/PaymentMerchantFactory.php
+++ b/src/database/factories/PaymentMerchantFactory.php
@@ -24,11 +24,8 @@ class PaymentMerchantFactory extends Factory
      */
     public function definition()
     {
-        $name = $this->faker->unique()->company();
-
         return [
-            'name' => $name,
-            'slug' => PaymentMerchant::slugify($name),
+            'slug' => PaymentMerchant::slugify($this->faker->unique()->company()),
         ];
     }
 }

--- a/src/database/factories/PaymentProviderFactory.php
+++ b/src/database/factories/PaymentProviderFactory.php
@@ -3,6 +3,7 @@
 namespace rkujawa\LaravelPaymentGateway\Database\Factories;
 
 use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Support\Str;
 use rkujawa\LaravelPaymentGateway\Models\PaymentProvider;
 
 class PaymentProviderFactory extends Factory
@@ -24,11 +25,13 @@ class PaymentProviderFactory extends Factory
      */
     public function definition()
     {
-        $name = $this->faker->unique()->company();
+        $slug = PaymentProvider::slugify($this->faker->unique()->company());
+        $studlySlug = Str::studly($slug);
 
         return [
-            'name' => $name,
-            'slug' => PaymentProvider::slugify($name),
+            'slug' => $slug,
+            'request_class' => "\App\Services\Payment\{$studlySlug}PaymentGateway",
+            'request_class' => "\App\Services\Payment\{$studlySlug}PaymentResponse",
         ];
     }
 }

--- a/src/database/migrations/2021_01_01_000000_create_base_payment_tables.php
+++ b/src/database/migrations/2021_01_01_000000_create_base_payment_tables.php
@@ -13,31 +13,33 @@ class CreateBasePaymentTables extends Migration
      */
     public function up()
     {
-        Schema::create('payment_providers', function (Blueprint $table) {
-            $table->smallIncrements('id');
-            $table->string('name');
-            $table->string('slug')->unique();
-            $table->timestamps();
-        });
+        if (config('payment.defaults.driver') === 'database') {
+            Schema::create('payment_providers', function (Blueprint $table) {
+                $table->smallIncrements('id');
+                $table->string('slug')->unique();
+                $table->string('request_class');
+                $table->string('response_class');
+                $table->timestamps();
+            });
 
-        Schema::create('payment_merchants', function (Blueprint $table) {
-            $table->mediumIncrements('id');
-            $table->string('name');
-            $table->string('slug')->unique();
-            $table->timestamps();
-        });
+            Schema::create('payment_merchants', function (Blueprint $table) {
+                $table->mediumIncrements('id');
+                $table->string('slug')->unique();
+                $table->timestamps();
+            });
 
-        Schema::create('payment_merchant_provider', function (Blueprint $table) {
-            $table->increments('id');
-            $table->unsignedMediumInteger('merchant_id');
-            $table->unsignedSmallInteger('provider_id');
-            $table->boolean('is_default')->default(false);
-            $table->json('config')->nullable();
-            $table->timestamps();
+            Schema::create('payment_merchant_provider', function (Blueprint $table) {
+                $table->increments('id');
+                $table->unsignedMediumInteger('merchant_id');
+                $table->unsignedSmallInteger('provider_id');
+                $table->boolean('is_default')->default(false);
+                $table->json('config')->nullable();
+                $table->timestamps();
 
-            $table->foreign('merchant_id')->references('id')->on('payment_merchants')->onDelete('cascade');
-            $table->foreign('provider_id')->references('id')->on('payment_providers')->onDelete('cascade');
-        });
+                $table->foreign('merchant_id')->references('id')->on('payment_merchants')->onDelete('cascade');
+                $table->foreign('provider_id')->references('id')->on('payment_providers')->onDelete('cascade');
+            });
+        }
 
         Schema::create('payment_types', function (Blueprint $table) {
             $table->smallIncrements('id');

--- a/src/stubs/config/payment.stub
+++ b/src/stubs/config/payment.stub
@@ -1,0 +1,89 @@
+<?php
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Payment Defaults
+    |--------------------------------------------------------------------------
+    |
+    | This option controls the default payment "provider" for your application.
+    | You may set these defaults as required, you should set your primary payments
+    | provider here, as it will be the provider to be injected automatically.
+    |
+    */
+    'defaults' => [
+        'driver' => 'config',
+        'provider' => '',
+        'merchant' => '',
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Payment Test Mode
+    |--------------------------------------------------------------------------
+    |
+    | When set to true, it will pass the provider & merchant into the testing
+    | gateway so you can mock your requests as you wish. This is very
+    | usefull when you are running tests in a CI/CD environment.
+    |
+    */
+    'test_mode' => env('PAYMENT_TEST_MODE', false),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Payment Provider Configurations
+    |--------------------------------------------------------------------------
+    |
+    | Here you may provide the location of your provider's gateway implementation
+    | by specifying the 'gateway' key for each provider and mapping the class to
+    | it, you may also add any provider specific configuration you might have.
+    |
+    */
+    'providers' => [
+        // 'example' => [
+        //     'id' => 1,
+        //     'slug' => 'example',
+        //     'request_class' => \App\Services\Payment\ExamplePaymentGateway::class,
+        //     'response_class' => \App\Services\Payment\ExamplePaymentResponse::class,
+        // ],
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Payment Merchants
+    |--------------------------------------------------------------------------
+    |
+    | Here you may specify all the merchants that will be supported by this application
+    | to process payments for, along with any configuration needed in order to do so. e.g. you may
+    | provide each merchant's api keys and endpoints
+    |
+    */
+    'merchants' => [
+        // 'example' => [
+        //     'id' => 1,
+        //     'slug' => 'example',
+        //     'providers' => [
+        //         'example' => [
+        //             'api_key' => '...'
+        //         ],
+        //     ],
+        // ],
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Payment Models
+    |--------------------------------------------------------------------------
+    |
+    | This option allows you to override the models to be used for managing payments.
+    | You may define your own models that extend the ones of the package in order to
+    | keep your relationships in sync with your own models.
+    |
+    */
+    // 'models' => [
+    //     \rkujawa\LaravelPaymentGateway\Models\PaymentMethod::class => \App\Models\Payment\PaymentMethod::class,
+    //     \rkujawa\LaravelPaymentGateway\Models\Wallet::class => \App\Models\Payment\Wallet::class,
+    // ],
+
+];

--- a/tests/Feature/AddPaymentTypeCommandTest.php
+++ b/tests/Feature/AddPaymentTypeCommandTest.php
@@ -35,7 +35,7 @@ class AddPaymentTypeCommandTest extends CommandTestCase
             ->expectsOutput($this->getMigrationOutput('type', $type->name))
             ->expectsConfirmation($this->getMigrationConfirmation(), 'yes')
             ->assertExitCode(0);
-        
+
             $this->assertDatabaseHas('payment_types', ['slug' => $type->slug]);
     }
 

--- a/tests/Unit/ConfigDriverTest.php
+++ b/tests/Unit/ConfigDriverTest.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace rkujawa\LaravelPaymentGateway\Tests\Unit;
+
+class ConfigDriverTest extends TestPaymentGateway
+{
+    protected $driver = 'config';
+}

--- a/tests/Unit/DatabaseDriverTest.php
+++ b/tests/Unit/DatabaseDriverTest.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace rkujawa\LaravelPaymentGateway\Tests\Unit;
+
+class DatabaseDriverTest extends TestPaymentGateway
+{
+    protected $driver = 'database';
+}

--- a/tests/Unit/TestPaymentGateway.php
+++ b/tests/Unit/TestPaymentGateway.php
@@ -1,21 +1,23 @@
 <?php
 
-namespace rkujawa\LaravelPaymentGateway\Tests;
+namespace rkujawa\LaravelPaymentGateway\Tests\Unit;
 
 use rkujawa\LaravelPaymentGateway\Facades\Payment;
 use rkujawa\LaravelPaymentGateway\Models\PaymentMethod;
 use rkujawa\LaravelPaymentGateway\Models\PaymentTransaction;
 use rkujawa\LaravelPaymentGateway\Models\Wallet;
 use rkujawa\LaravelPaymentGateway\PaymentResponse;
+use rkujawa\LaravelPaymentGateway\Tests\GatewayTestCase;
+use rkujawa\LaravelPaymentGateway\Tests\User;
 
-class ProviderGatewayTest extends GatewayTestCase
+class TestPaymentGateway extends GatewayTestCase
 {
     /** @test */
     public function get_wallet_method_returns_configured_response()
     {
         $wallet = Wallet::factory()->create([
-            'provider_id' => $this->provider->id,
-            'merchant_id' => $this->merchant->id,
+            'provider_id' => Payment::getProvider()->getId(),
+            'merchant_id' => Payment::getMerchant()->getId(),
         ]);
 
         $response = Payment::getWallet($wallet);
@@ -29,8 +31,8 @@ class ProviderGatewayTest extends GatewayTestCase
     public function get_payment_method_method_returns_configured_response()
     {
         $wallet = Wallet::factory()->create([
-            'provider_id' => $this->provider->id,
-            'merchant_id' => $this->merchant->id,
+            'provider_id' => Payment::getProvider()->getId(),
+            'merchant_id' => Payment::getMerchant()->getId(),
         ]);
 
         $paymentMethod = PaymentMethod::factory()->create([
@@ -60,8 +62,8 @@ class ProviderGatewayTest extends GatewayTestCase
     public function update_payment_method_method_returns_configured_response()
     {
         $wallet = Wallet::factory()->create([
-            'provider_id' => $this->provider->id,
-            'merchant_id' => $this->merchant->id,
+            'provider_id' => Payment::getProvider()->getId(),
+            'merchant_id' => Payment::getMerchant()->getId(),
         ]);
 
         $paymentMethod = PaymentMethod::factory()->create([
@@ -79,8 +81,8 @@ class ProviderGatewayTest extends GatewayTestCase
     public function delete_payment_method_method_returns_configured_response()
     {
         $wallet = Wallet::factory()->create([
-            'provider_id' => $this->provider->id,
-            'merchant_id' => $this->merchant->id,
+            'provider_id' => Payment::getProvider()->getId(),
+            'merchant_id' => Payment::getMerchant()->getId(),
         ]);
 
         $paymentMethod = PaymentMethod::factory()->create([
@@ -108,8 +110,8 @@ class ProviderGatewayTest extends GatewayTestCase
     public function capture_method_returns_configured_response()
     {
         $transaction = PaymentTransaction::factory()->create([
-            'provider_id' => $this->provider->id,
-            'merchant_id' => $this->merchant->id,
+            'provider_id' => Payment::getProvider()->getId(),
+            'merchant_id' => Payment::getMerchant()->getId(),
         ]);
 
         $response = Payment::capture($transaction);
@@ -123,8 +125,8 @@ class ProviderGatewayTest extends GatewayTestCase
     public function void_method_returns_configured_response()
     {
         $transaction = PaymentTransaction::factory()->create([
-            'provider_id' => $this->provider->id,
-            'merchant_id' => $this->merchant->id,
+            'provider_id' => Payment::getProvider()->getId(),
+            'merchant_id' => Payment::getMerchant()->getId(),
         ]);
 
         $response = Payment::void($transaction);
@@ -138,8 +140,8 @@ class ProviderGatewayTest extends GatewayTestCase
     public function refund_method_returns_configured_response()
     {
         $transaction = PaymentTransaction::factory()->create([
-            'provider_id' => $this->provider->id,
-            'merchant_id' => $this->merchant->id,
+            'provider_id' => Payment::getProvider()->getId(),
+            'merchant_id' => Payment::getMerchant()->getId(),
         ]);
 
         $response = Payment::refund($transaction);
@@ -158,7 +160,7 @@ class ProviderGatewayTest extends GatewayTestCase
      */
     protected function assertResponseIsConfigured(PaymentResponse $response)
     {
-        $this->assertEquals(Payment::getProvider()->id, $response->provider->id);
-        $this->assertEquals(Payment::getMerchant()->id, $response->merchant->id);
+        $this->assertEquals(Payment::getProvider()->getId(), $response->provider->id);
+        $this->assertEquals(Payment::getMerchant()->getId(), $response->merchant->id);
     }
 }


### PR DESCRIPTION
### **What does this PR do?** :robot:

- Extracts `PaymentService::class` logic into a `DatabaseDriver::class`.
- Adds a `ConfigDriver::class` for most use cases.
- Sets the `ConfigDriver::class` as default for this package.

### **Where should the reviewer start?** :round_pushpin:
`PaymentService::class`, notice how the logic begins to be executed by a driver, either config or database is supported out of the box.

### **How should this be tested?** :microscope:
Require this package locally and test using both drivers.

### **Any background context you would like to provide?** :construction:
This is definitely a breaking change, since the config driver is default now.

### **Does this relate to any issue?** :link:
Closes #81 
