### PR TITLE
[2.x] Simplify transaction requests.

### DIFF
--- a/src/Console/stubs/payment-gateway.stub
+++ b/src/Console/stubs/payment-gateway.stub
@@ -102,6 +102,17 @@ class {{ name }}PaymentGateway extends PaymentRequest
     }
 
     /**
+     * Retrieve the transaction details from the provider.
+     *
+     * @param \rkujawa\LaravelPaymentGateway\Models\PaymentTransaction $transaction
+     * @return \rkujawa\LaravelPaymentGateway\PaymentResponse
+     */
+    public function getTransaction(PaymentTransaction $transaction)
+    {
+        //
+    }
+
+    /**
      * Void a previously authorized transaction.
      *
      * @param \rkujawa\LaravelPaymentGateway\Models\PaymentTransaction $paymentTransaction

--- a/src/Console/stubs/payment-response.stub
+++ b/src/Console/stubs/payment-response.stub
@@ -87,6 +87,16 @@ class {{ name }}PaymentResponse extends PaymentResponse
     }
 
     /**
+     * Maps details from the getTransaction() response to the expected format.
+     * 
+     * @return array|mixed
+     */
+    public function getTransactionResponse()
+    {
+        //
+    }
+
+    /**
      * Maps details from the void() response to the expected format.
      *
      * @return array|mixed

--- a/src/Contracts/PaymentRequestor.php
+++ b/src/Contracts/PaymentRequestor.php
@@ -70,6 +70,14 @@ interface PaymentRequestor
     public function capture(PaymentTransaction $transaction, $data = []);
 
     /**
+     * Retrieve the transaction details from the provider.
+     *
+     * @param \rkujawa\LaravelPaymentGateway\Models\PaymentTransaction $transaction
+     * @return \rkujawa\LaravelPaymentGateway\PaymentResponse
+     */
+    public function getTransaction(PaymentTransaction $transaction);
+
+    /**
      * Void a previously authorized transaction.
      * 
      * @param \rkujawa\LaravelPaymentGateway\Models\PaymentTransaction $transaction

--- a/src/Contracts/PaymentResponder.php
+++ b/src/Contracts/PaymentResponder.php
@@ -54,6 +54,13 @@ interface PaymentResponder
     public function captureResponse();
 
     /**
+     * Maps details from the getTransaction() response to the expected format.
+     * 
+     * @return array|mixed
+     */
+    public function getTransactionResponse();
+
+    /**
      * Maps details from the void() response to the expected format.
      *
      * @return array|mixed

--- a/src/Facades/Payment.php
+++ b/src/Facades/Payment.php
@@ -21,6 +21,7 @@ use rkujawa\LaravelPaymentGateway\PaymentGateway;
  * @method static \rkujawa\LaravelPaymentGateway\PaymentResponse deletePaymentMethod(\rkujawa\LaravelPaymentGateway\Models\PaymentMethod $paymentMethod)
  * @method static \rkujawa\LaravelPaymentGateway\PaymentResponse authorize($data, \rkujawa\LaravelPaymentGateway\Contracts\Billable $billable = null)
  * @method static \rkujawa\LaravelPaymentGateway\PaymentResponse capture(\rkujawa\LaravelPaymentGateway\Models\PaymentTransaction $transaction, $data = [])
+ * @method static \rkujawa\LaravelPaymentGateway\PaymentResponse getTransaction(\rkujawa\LaravelPaymentGateway\Models\PaymentTransaction $transaction)
  * @method static \rkujawa\LaravelPaymentGateway\PaymentResponse void(\rkujawa\LaravelPaymentGateway\Models\PaymentTransaction $transaction, $data = [])
  * @method static \rkujawa\LaravelPaymentGateway\PaymentResponse refund(\rkujawa\LaravelPaymentGateway\Models\PaymentTransaction $transaction, $data = [])
  * 

--- a/src/Models/PaymentTransaction.php
+++ b/src/Models/PaymentTransaction.php
@@ -5,10 +5,12 @@ namespace rkujawa\LaravelPaymentGateway\Models;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use rkujawa\LaravelPaymentGateway\Database\Factories\PaymentTransactionFactory;
+use rkujawa\LaravelPaymentGateway\Models\Traits\PaymentTransactionRequests;
 
 class PaymentTransaction extends Model
 {
-    use HasFactory;
+    use HasFactory,
+        PaymentTransactionRequests;
 
     /**
      * The attributes that aren't mass assignable.

--- a/src/Models/PaymentTransactionEvent.php
+++ b/src/Models/PaymentTransactionEvent.php
@@ -54,24 +54,4 @@ class PaymentTransactionEvent extends Model
     {
         return $this->belongsTo(config('payment.models.' . PaymentTransaction::class, PaymentTransaction::class));
     }
-
-    /**
-     * Get the transactions event's provider.
-     *
-     * @return \rkujawa\LaravelPaymentGateway\Models\PaymentProvider
-     */
-    public function getProviderAttribute()
-    {
-        return $this->transaction->provider;
-    }
-
-    /**
-     * Get the transaction event's merchant.
-     *
-     * @return \rkujawa\LaravelPaymentGateway\Models\PaymentMerchant
-     */
-    public function getMerchantAttribute()
-    {
-        return $this->transaction->merchant;
-    }
 }

--- a/src/Models/PaymentTransactionEvent.php
+++ b/src/Models/PaymentTransactionEvent.php
@@ -54,4 +54,24 @@ class PaymentTransactionEvent extends Model
     {
         return $this->belongsTo(config('payment.models.' . PaymentTransaction::class, PaymentTransaction::class));
     }
+
+    /**
+     * Get the transactions event's provider.
+     *
+     * @return \rkujawa\LaravelPaymentGateway\Models\PaymentProvider
+     */
+    public function getProviderAttribute()
+    {
+        return $this->transaction->provider;
+    }
+
+    /**
+     * Get the transaction event's merchant.
+     *
+     * @return \rkujawa\LaravelPaymentGateway\Models\PaymentMerchant
+     */
+    public function getMerchantAttribute()
+    {
+        return $this->transaction->merchant;
+    }
 }

--- a/src/Models/Traits/PaymentTransactionRequests.php
+++ b/src/Models/Traits/PaymentTransactionRequests.php
@@ -37,15 +37,4 @@ trait PaymentTransactionRequests
     {
         return $this->gateway->refund($this, $data);
     }
-
-    /**
-     * Request the provider to reverse the transaction.
-     *
-     * @param array|mixed $data
-     * @return \rkujawa\LaravelPaymentGateway\PaymentResponse
-     */
-    public function reverse($data = [])
-    {
-        return $this->gateway->reverse($this, $data);
-    }
 }

--- a/src/Models/Traits/PaymentTransactionRequests.php
+++ b/src/Models/Traits/PaymentTransactionRequests.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace rkujawa\LaravelPaymentGateway\Models\Traits;
+
+trait PaymentTransactionRequests
+{
+    use ConfiguresPaymentGateway;
+
+    /**
+     * Fetch the transaction details from the provider.
+     *
+     * @return \rkujawa\LaravelPaymentGateway\PaymentResponse
+     */
+    public function fetch()
+    {
+        return $this->gateway->getTransaction($this);
+    }
+
+    /**
+     * Request the provider to void the transaction.
+     *
+     * @param array|mixed $data
+     * @return \rkujawa\LaravelPaymentGateway\PaymentResponse
+     */
+    public function void($data = [])
+    {
+        return $this->gateway->void($this, $data);
+    }
+
+    /**
+     * Request the provider to refund the transaction.
+     *
+     * @param array|mixed $data
+     * @return \rkujawa\LaravelPaymentGateway\PaymentResponse
+     */
+    public function refund($data = [])
+    {
+        return $this->gateway->refund($this, $data);
+    }
+
+    /**
+     * Request the provider to reverse the transaction.
+     *
+     * @param array|mixed $data
+     * @return \rkujawa\LaravelPaymentGateway\PaymentResponse
+     */
+    public function reverse($data = [])
+    {
+        return $this->gateway->reverse($this, $data);
+    }
+}

--- a/src/PaymentGateway.php
+++ b/src/PaymentGateway.php
@@ -93,6 +93,17 @@ class PaymentGateway extends PaymentService implements PaymentRequestor
     }
 
     /**
+     * Retrieve the transaction details from the provider.
+     *
+     * @param \rkujawa\LaravelPaymentGateway\Models\PaymentTransaction $transaction
+     * @return \rkujawa\LaravelPaymentGateway\PaymentResponse
+     */
+    public function getTransaction(PaymentTransaction $transaction)
+    {
+        return tap($this->gateway->getTransaction($transaction))->configure(__FUNCTION__, $this->provider, $this->merchant);
+    }
+
+    /**
      * Void a previously authorized transaction.
      * 
      * @param \rkujawa\LaravelPaymentGateway\Models\PaymentTransaction $transaction

--- a/src/Traits/PaymentRequests.php
+++ b/src/Traits/PaymentRequests.php
@@ -93,6 +93,17 @@ trait PaymentRequests
     }
 
     /**
+     * Retrieve the transaction details from the provider.
+     *
+     * @param \rkujawa\LaravelPaymentGateway\Models\PaymentTransaction $transaction
+     * @return \rkujawa\LaravelPaymentGateway\PaymentResponse
+     */
+    public function getTransaction(PaymentTransaction $transaction)
+    {
+        $this->throwRuntimeException(__FUNCTION__);
+    }
+
+    /**
      * Void a previously authorized transaction.
      * 
      * @param \rkujawa\LaravelPaymentGateway\Models\PaymentTransaction $paymentTransaction

--- a/src/Traits/PaymentResponses.php
+++ b/src/Traits/PaymentResponses.php
@@ -77,6 +77,16 @@ trait PaymentResponses
     }
 
     /**
+     * Maps details from the getTransaction() response to the expected format.
+     * 
+     * @return array|mixed
+     */
+    public function getTransactionResponse()
+    {
+        $this->throwRuntimeException(__FUNCTION__);
+    }
+
+    /**
      * Maps details from the void() response to the expected format.
      *
      * @return array|mixed

--- a/tests/GatewayTestCase.php
+++ b/tests/GatewayTestCase.php
@@ -98,12 +98,17 @@ class TestPaymentGateway extends PaymentRequest
         return new TestPaymentResponse([]);
     }
 
-    public function void(PaymentTransaction $paymentTransaction, $data =[])
+    public function getTransaction(PaymentTransaction $transaction)
     {
         return new TestPaymentResponse([]);
     }
 
-    public function refund(PaymentTransaction $paymentTransaction, $data = [])
+    public function void(PaymentTransaction $transaction, $data =[])
+    {
+        return new TestPaymentResponse([]);
+    }
+
+    public function refund(PaymentTransaction $transaction, $data = [])
     {
         return new TestPaymentResponse([]);
     }
@@ -154,6 +159,13 @@ class TestPaymentResponse extends PaymentResponse
     }
 
     public function captureResponse()
+    {
+        return [
+            'requestMethod' => $this->requestMethod,
+        ];
+    }
+
+    public function getTransactionResponse()
     {
         return [
             'requestMethod' => $this->requestMethod,

--- a/tests/Unit/ProviderGatewayTest.php
+++ b/tests/Unit/ProviderGatewayTest.php
@@ -120,6 +120,21 @@ class ProviderGatewayTest extends GatewayTestCase
     }
 
     /** @test */
+    public function get_transaction_method_returns_configured_response()
+    {
+        $transaction = PaymentTransaction::factory()->create([
+            'provider_id' => $this->provider->id,
+            'merchant_id' => $this->merchant->id,
+        ]);
+
+        $response = Payment::getTransaction($transaction);
+
+        $this->assertResponseIsConfigured($response);
+
+        $this->assertEquals('getTransaction', $response->data['requestMethod']);
+    }
+
+    /** @test */
     public function void_method_returns_configured_response()
     {
         $transaction = PaymentTransaction::factory()->create([


### PR DESCRIPTION
### **What does this PR do?** :robot:

- Makes it easier to make requests to the provider directly from the e`PaymentTransaction::class` model object.
- Configures the gateway provider & merchant automatically to improve the developer experience by 10x 😝.

### **Where should the reviewer start?** :round_pushpin:
Only minor changes, just take a look at the code.

### **How should this be tested?** :microscope:
Go ahead and test the following methods in a PSP's sandbox:

1. The `getTransaction()` method is mapped to the `PaymentTransaction::class` model's `fetch()` method.
2. The `void()`, `refund()` & `reverse()` methods remain the same in the `PaymentTransaction::class` model.

### **Any background context you would like to provide?** :construction:
The reason for this PR is to add support for requests just like for the `PaymentMethod::class` model.
