### PR TITLE
[2.x] Add chargeback `PaymentStatus:class` constants

### DIFF
--- a/src/PaymentStatus.php
+++ b/src/PaymentStatus.php
@@ -16,6 +16,8 @@ class PaymentStatus
     const REFUND_SETTLED = 214;
     const REFUND_FAILED = 215;
     const REFUND_REVERSED = 216;
+    const CHARGEBACK = 220;
+    const CHARGEBACK_REVERSED = 221;
     const PENDING = 300;
     const PROCESSING_ASYNC = 301;
     const REFUSED = 400;
@@ -70,6 +72,8 @@ class PaymentStatus
         self::REFUND_SETTLED => 'Refund settled',
         self::REFUND_FAILED => 'Refund failed',
         self::REFUND_REVERSED => 'Refund reversed',
+        self::CHARGEBACK => 'Charged back',
+        self::CHARGEBACK_REVERSED => 'Chargeback reversed',
         self::PENDING => 'Pending',
         self::PROCESSING_ASYNC => 'Processing asynchronously',
         self::REFUSED => 'Refused',
@@ -125,6 +129,8 @@ class PaymentStatus
         self::REFUND_SETTLED => 'The refund was settled.',
         self::REFUND_FAILED => 'The refund failed to be processed.',
         self::REFUND_REVERSED => 'The refund was reversed and settled.',
+        self::CHARGEBACK => 'The transaction was charged back.',
+        self::CHARGEBACK_REVERSED => 'The chargeback was reversed and settled.',
         self::PENDING => 'The transaction is pending.',
         self::PROCESSING_ASYNC => 'The transaction is being completed asynchronously.',
         self::REFUSED => 'The transaction was refused.',


### PR DESCRIPTION
### **What does this PR do?** :robot:
Adds the necessary `PaymentStatus::class` constants to support chargebacks.

### **Does this relate to any issue?** :link:
Closes #92 
