### PR TITLE
[3.x] Change TestPaymentGateway to FakePaymentGateway.

### DIFF
--- a/src/Console/Commands/AddPaymentProvider.php
+++ b/src/Console/Commands/AddPaymentProvider.php
@@ -18,7 +18,7 @@ class AddPaymentProvider extends Command
     protected $signature = 'payment:add-provider
                             {provider? : The payment provider name}
                             {--id= : The payment provider identifier}
-                            {--test : Generates a gateway to be used for testing purposes}';
+                            {--fake : Generates a gateway to be used for testing purposes}';
 
     /**
      * The console command description.
@@ -64,12 +64,15 @@ class AddPaymentProvider extends Command
      */
     protected function setProperties()
     {
+        if ($this->option('fake', false)) {
+            $this->name = 'Fake';
+            $this->id = 'fake';
+
+            return;
+        }
+
         $this->name = trim(
-            $this->argument('provider') ?? (
-                $this->option('test', false)
-                    ? 'Test'
-                    : $this->ask('What payment provider would you like to add?')
-            )
+            $this->argument('provider') ?? $this->ask('What payment provider would you like to add?')
         );
 
         $this->id =

--- a/src/PaymentService.php
+++ b/src/PaymentService.php
@@ -196,7 +196,7 @@ class PaymentService
         }
 
         $gateway = config('payment.test_mode', false)
-            ? config('payment.test.gateway', '\\App\\Services\\Payment\\TestPaymentGateway')
+            ? config('payment.test.gateway', '\\App\\Services\\Payment\\FakePaymentGateway')
             : $this->driver->resolveGatewayClass($provider);
 
         if (! class_exists($gateway)) {

--- a/tests/Feature/AddPaymentProviderCommandTest.php
+++ b/tests/Feature/AddPaymentProviderCommandTest.php
@@ -35,18 +35,16 @@ class AddPaymentProviderCommandTest extends TestCase
     }
 
     /** @test */
-    public function add_payment_provider_command_with_test_argument_generates_test_gateway()
+    public function add_payment_provider_command_with_fake_argument_generates_fake_gateway()
     {
         $arguments = [
-            '--test' => true,
+            '--fake' => true,
         ];
 
         $this->artisan('payment:add-provider', $arguments)
-            ->expectsQuestion('How would you like to identify the Test payment provider?', 'test')
             ->assertExitCode(0);
 
-
-        $this->assertGatewayExists('test');
+        $this->assertGatewayExists('fake');
     }
 
     private function assertGatewayExists(string $id)


### PR DESCRIPTION
### **What does this PR do?** :robot:
- Updates `TestPaymentGateway::class` sourounding logic to reference it as `FakePaymentGateway::class`.

### **Any background context you would like to provide?** :construction:
The main motive for these changes is to adapt to the general mocking standard, where most testing helpers are referenced as `fake`.

### **Does this relate to any issue?** :link:
Closes #94 
